### PR TITLE
fix date parsing and typo

### DIFF
--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import datetime
+from dateutil.parser import parse as parse_date
 
 from . import connection
 
@@ -37,23 +38,21 @@ class LXDOperation(object):
 
     def operation_create_time(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object('GET', '/1.0/Ooperations/%s'
+            (state, data) = self.connection.get_object('GET', '/1.0/operations/%s'
                                                        % operation)
             data = data.get('metadata')
-        return datetime.datetime.fromtimestamp(data['created_at']) \
-            .strftime('%Y-%m-%d %H:%M:%S')
+        return parse_date(data['created_at']).strftime('%Y-%m-%d %H:%M:%S')
 
     def operation_update_time(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object('GET', '/1.0/Ooperations/%s'
+            (state, data) = self.connection.get_object('GET', '/1.0/operations/%s'
                                                        % operation)
             data = data.get('metadata')
-        return datetime.datetime.fromtimestamp(data['updated_at']) \
-            .strftime('%Y-%m-%d %H:%M:%S')
+        return parse_date(data['updated_at']).strftime('%Y-%m-%d %H:%M:%S')
 
     def operation_status_code(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object('GET', '/1.0/Ooperations/%s'
+            (state, data) = self.connection.get_object('GET', '/1.0/operations/%s'
                                                        % operation)
             data = data.get('metadata')
         return data['status']

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 pbr>=0.6,!=0.7,<=1.0.1
 Babel>=1.3
+python-dateutil


### PR DESCRIPTION
Signed-off-by: Matthew Williams <mgwilliams@gmail.com>

Although the API spec says unix timestamps are returned by the API, in fact they are of the format `2015-06-09T21:05:29.00502626Z` (this is true in 0.9 through 0.11).

If it is desirable to avoid the dependency on python-dateutil, I can write a helper function using strptime. Or pylxd could just return the timestamp verbatim as returned by the API, since it's already human readable.

This PR also fixes a small typo that was causing a `404`.