### PR TITLE
Ensure TLS 1.2 protocol is enforced when communicating with LXD over …

### DIFF
--- a/pylxd/connection.py
+++ b/pylxd/connection.py
@@ -65,7 +65,8 @@ class HTTPSConnection(http_client.HTTPConnection):
 
         (cert_file, key_file) = self._get_ssl_certs()
         self.sock = ssl.wrap_socket(sock, certfile=cert_file,
-                                    keyfile=key_file)
+                                    keyfile=key_file,
+                                    ssl_version=ssl.PROTOCOL_TLSv1_2)
 
     @staticmethod
     def _get_ssl_certs():

--- a/pylxd/tests/test_connection.py
+++ b/pylxd/tests/test_connection.py
@@ -18,6 +18,7 @@ import mock
 from six.moves import cStringIO
 from six.moves import http_client
 import socket
+import ssl
 import unittest
 
 from pylxd import connection
@@ -51,7 +52,8 @@ class LXDInitConnectionTest(unittest.TestCase):
             ml.assert_called_once_with(
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
-                keyfile='/home/foo/.config/lxc/client.key'
+                keyfile='/home/foo/.config/lxc/client.key',
+                ssl_version=ssl.PROTOCOL_TLSv1_2,
             )
 
     @mock.patch('os.environ', {'HOME': '/home/foo'})
@@ -69,6 +71,7 @@ class LXDInitConnectionTest(unittest.TestCase):
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
                 keyfile='/home/foo/.config/lxc/client.key'
+                ssl_version=ssl.PROTOCOL_TLSv1_2,
             )
 
     @mock.patch('pylxd.connection.HTTPSConnection')


### PR DESCRIPTION
…HTTPS

LXD enforces this version:

    tlsConfig := &tls.Config{
        InsecureSkipVerify: true,
        ClientAuth:         tls.RequireAnyClientCert,
        Certificates:       []tls.Certificate{cert},
        MinVersion:         tls.VersionTLS12,
        MaxVersion:         tls.VersionTLS12,
        CipherSuites: []uint16{
            tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
            tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
        PreferServerCipherSuites: true,
    }
