### PR TITLE
Switch to using get_object in image_upload

### DIFF
--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -169,7 +169,7 @@ class LXDImage(base.LXDBase):
     def image_upload(self, path=None, data=None, headers={}):
         data = data or open(path, 'rb').read()
         try:
-            return self.connection.get_status('POST', '/1.0/images',
+            return self.connection.get_object('POST', '/1.0/images',
                                               data, headers)
         except Exception as e:
             print("Unable to upload image - {}".format(e))

--- a/pylxd/tests/test_image.py
+++ b/pylxd/tests/test_image.py
@@ -123,7 +123,6 @@ class LXDAPIImageTestObject(LXDAPITestBase):
 @mock.patch.object(connection.LXDConnection, 'get_status', return_value=True)
 class LXDAPIImageTestStatus(LXDAPITestBase):
     operations_data = (
-        ('upload', 'POST', '', (None, 'fake'), ('fake', {}, )),
         ('delete', 'DELETE', '/test-image', ('test-image',), ()),
         ('update', 'PUT', '/test-image', ('test-image', 'fake',), ('"fake"',)),
         ('rename', 'POST', '/test-image',
@@ -153,6 +152,10 @@ class LXDAPIImageTestStatus(LXDAPITestBase):
             *call_args
         )
 
+
+@mock.patch.object(connection.LXDConnection, 'get_object',
+                   return_value=('200', fake_api.fake_image_info()))
+class LXDAPAPIImageTestUpload(LXDAPITestBase):
     @mock.patch.object(builtins, 'open', return_value=cStringIO('fake'))
     def test_image_upload_file(self, mo, ms):
         self.assertTrue(self.lxd.image_upload(path='/fake/path'))


### PR DESCRIPTION
LXD returns some data on upload; pass it back to callers.