### PR TITLE
faster behavior for determining if a container is defined

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -15,6 +15,7 @@
 import json
 
 from pylxd import base
+from pylxd import exceptions
 
 
 class LXDContainer(base.LXDBase):
@@ -45,8 +46,17 @@ class LXDContainer(base.LXDBase):
                                           % container, json.dumps(config))
 
     def container_defined(self, container):
-        return self.connection.get_status('GET', '/1.0/containers/%s/state'
-                                          % container)
+        _, data = self.connection.get_object('GET', '/1.0/containers')
+        try:
+            containers = data["metadata"]
+        except KeyError:
+            raise exceptions.PyLXDException("no metadata in GET containers?")
+
+        container_url = "/1.0/containers/%s" % container
+        for ct in containers:
+            if ct == container_url:
+                return True
+        return False
 
     def container_state(self, container):
         return self.connection.get_object(

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -13,7 +13,6 @@
 #    under the License.
 
 from collections import OrderedDict
-from ddt import data
 from ddt import ddt
 import json
 import mock
@@ -201,15 +200,13 @@ class LXDAPIContainerTestObject(LXDAPITestBase):
 
 
 @ddt
-@mock.patch.object(connection.LXDConnection, 'get_status')
+@mock.patch.object(connection.LXDConnection, 'get_object',
+                   return_value=('200', fake_api.fake_container_list()))
 class LXDAPIContainerTestStatus(LXDAPITestBase):
 
-    @data(True, False)
-    def test_container_defined(self, defined, ms):
-        ms.return_value = defined
-        self.assertEqual(defined, self.lxd.container_defined('trusty-1'))
-        ms.assert_called_once_with('GET',
-                                   '/1.0/containers/trusty-1/state')
+    def test_container_defined(self, ms):
+        self.assertTrue(self.lxd.container_defined('trusty-1'))
+        ms.assert_called_once_with('GET', '/1.0/containers')
 
 
 @ddt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 0.18
+version = 0.18.1
 description-file =
     README.md
 author = Chuck Short


### PR DESCRIPTION
Instead of trying to get the state (which causes LXD to do a bunch of
forking/setnsing crap that is quite slow). Instead, let's just query the
list of the containers, which, in LXD is a DB query, and check if our
container is in that list.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>