### PR TITLE
refer to the operation by its URL always

### DIFF
--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -21,12 +21,11 @@ class LXDOperation(base.LXDBase):
 
     def operation_list(self):
         (state, data) = self.connection.get_object('GET', '/1.0/operations')
-        return [operation.split('/1.0/operations/')[-1]
-                for operation in data['metadata']]
+        return data['metadata']
 
     def operation_show(self, operation):
-        (state, data) = self.connection.get_object('GET', '/1.0/operations/%s'
-                                                   % operation)
+        (state, data) = self.connection.get_object('GET', operation)
+
         return {
             'operation_create_time':
                 self.operation_create_time(operation, data.get('metadata')),
@@ -37,40 +36,34 @@ class LXDOperation(base.LXDBase):
         }
 
     def operation_info(self, operation):
-        return self.connection.get_object('GET', '/1.0/operations/%s'
-                                          % operation)
+        return self.connection.get_object('GET', operation)
 
     def operation_create_time(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object(
-                'GET', '/1.0/operations/%s' % operation)
+            (state, data) = self.connection.get_object('GET', operation)
             data = data.get('metadata')
         return parse_date(data['created_at']).strftime('%Y-%m-%d %H:%M:%S')
 
     def operation_update_time(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object(
-                'GET', '/1.0/operations/%s' % operation)
+            (state, data) = self.connection.get_object('GET', operation)
             data = data.get('metadata')
         return parse_date(data['updated_at']).strftime('%Y-%m-%d %H:%M:%S')
 
     def operation_status_code(self, operation, data):
         if data is None:
-            (state, data) = self.connection.get_object(
-                'GET', '/1.0/operations/%s' % operation)
+            (state, data) = self.connection.get_object('GET', operation)
             data = data.get('metadata')
         return data['status']
 
     def operation_wait(self, operation, status_code, timeout):
         return self.connection.get_status(
-            'GET', '/1.0/operations/%s/wait?status_code=%s&timeout=%s'
+            'GET', '%s/wait?status_code=%s&timeout=%s'
             % (operation, status_code, timeout))
 
     def operation_stream(self, operation, operation_secret):
         return self.connection.get_ws(
-            'GET', '/1.0/operations/%s/websocket?secret=%s'
-            % (operation, operation_secret))
+            'GET', '%s/websocket?secret=%s' % (operation, operation_secret))
 
     def operation_delete(self, operation):
-        return self.connection.get_status('DELETE', '/1.0/operations/%s'
-                                          % operation)
+        return self.connection.get_status('DELETE', operation)

--- a/pylxd/tests/test_operation.py
+++ b/pylxd/tests/test_operation.py
@@ -31,7 +31,7 @@ class LXDAPIOperationTestObject(LXDAPITestBase):
     def test_list_operations(self, ms):
         ms.return_value = ('200', fake_api.fake_operation_list())
         self.assertEqual(
-            ['1234'],
+            ['/1.0/operations/1234'],
             self.lxd.list_operations())
         ms.assert_called_with('GET',
                               '/1.0/operations')
@@ -39,7 +39,7 @@ class LXDAPIOperationTestObject(LXDAPITestBase):
     def test_operation_info(self, ms):
         ms.return_value = ('200', fake_api.fake_operation())
         self.assertEqual(
-            ms.return_value, self.lxd.operation_info('1234'))
+            ms.return_value, self.lxd.operation_info('/1.0/operations/1234'))
         ms.assert_called_with('GET',
                               '/1.0/operations/1234')
 
@@ -53,9 +53,8 @@ class LXDAPIOperationTestObject(LXDAPITestBase):
         ('status', 'Running'),
     )
     def test_operation_show(self, method, expected, ms):
-        self.assertEqual(
-            expected, getattr(self.lxd,
-                              'operation_show_' + method)('1234'))
+        call = getattr(self.lxd, 'operation_show_' + method)
+        self.assertEqual(expected, call('/1.0/operations/1234'))
         ms.assert_called_with('GET',
                               '/1.0/operations/1234')
 
@@ -71,6 +70,6 @@ class LXDAPIOperationTestStatus(LXDAPITestBase):
     )
     def test_operation_actions(self, method, http, path, args, ms):
         self.assertTrue(
-            getattr(self.lxd, method)('1234', *args))
+            getattr(self.lxd, method)('/1.0/operations/1234', *args))
         ms.assert_called_with(http,
                               '/1.0/operations/1234' + path)


### PR DESCRIPTION
Instead of sometimes (in the case of list_operations) referring to
operations by their actual UUID and others (in the case of grabbing what
the API returns directly out of the response) referring to operations by
their full URL, let's just always use the full URL.

Closes #8

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>