### PR TITLE
Fix issue in LXDContainer.container_running() method

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -32,8 +32,8 @@ class LXDContainer(base.LXDBase):
             '/1.0/containers/%s/state' % container)
         data = data.get('metadata')
         container_running = False
-        if data['status'] in ['RUNNING', 'STARTING', 'FREEZING', 'FROZEN',
-                              'THAWED']:
+        if data['status'].upper() in ['RUNNING', 'STARTING', 'FREEZING',
+                                      'FROZEN', 'THAWED']:
             container_running = True
         return container_running
 


### PR DESCRIPTION
Current code compares 'status' field in camel case with
with predefined statuses in upper case. That's why method
container_running() always returns False, even if container
is running.