### PR TITLE
Remove get_ws() method stub with real websocket implementation

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -131,7 +131,6 @@ class LXDContainer(base.LXDBase):
 
     def container_migrate_sync(self, operation_id, container_secret):
         return self.connection.get_ws(
-            'GET',
             '/1.0/operations/%s/websocket?secret=%s'
             % (operation_id, container_secret))
 

--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -63,7 +63,7 @@ class LXDOperation(base.LXDBase):
 
     def operation_stream(self, operation, operation_secret):
         return self.connection.get_ws(
-            'GET', '%s/websocket?secret=%s' % (operation, operation_secret))
+            '%s/websocket?secret=%s' % (operation, operation_secret))
 
     def operation_delete(self, operation):
         return self.connection.get_status('DELETE', operation)

--- a/pylxd/tests/test_connection.py
+++ b/pylxd/tests/test_connection.py
@@ -147,3 +147,15 @@ class LXDConnectionTest(unittest.TestCase):
             self.assertRaises(result, self.conn.get_raw)
         else:
             self.assertEqual(result, self.conn.get_raw())
+
+    @mock.patch('pylxd.connection.WebSocketClient')
+    @annotated_data(
+        ('fake_host', 'wss://fake_host:8443'),
+        (None, 'ws+unix:///var/lib/lxd/unix.socket')
+    )
+    def test_get_ws(self, host, result, mock_ws, _):
+        conn = connection.LXDConnection(host)
+
+        conn.get_ws('/fake/path')
+
+        mock_ws.assert_has_calls([mock.call(result), mock.call().connect()])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Babel>=1.3
 python-dateutil>=2.4.2
 six>=1.9.0
 pyOpenSSL>=0.14
+ws4py>=0.3.4


### PR DESCRIPTION
This commit adds websockets support in PyLXD library which allows
users track progress and output of executed operations and commands.

This commit is required to use PyLXD in Openstack Manila project.

This pull request closes issue #26