### PR TITLE
Detect SSL tls version

### DIFF
--- a/pylxd/connection.py
+++ b/pylxd/connection.py
@@ -27,6 +27,7 @@ if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
 else:
     DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1
 
+
 class UnixHTTPConnection(http_client.HTTPConnection):
 
     def __init__(self, path, host='localhost', port=None, strict=None,

--- a/pylxd/connection.py
+++ b/pylxd/connection.py
@@ -21,6 +21,11 @@ from pylxd import exceptions
 from pylxd import utils
 from six.moves import http_client
 
+# Detect SSL tls version
+if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+    DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
+else:
+    DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1
 
 class UnixHTTPConnection(http_client.HTTPConnection):
 
@@ -54,7 +59,7 @@ class HTTPSConnection(http_client.HTTPConnection):
         (cert_file, key_file) = self._get_ssl_certs()
         self.sock = ssl.wrap_socket(sock, certfile=cert_file,
                                     keyfile=key_file,
-                                    ssl_version=ssl.PROTOCOL_TLSv1_2)
+                                    ssl_version=DEFAULT_TLS_VERSION)
 
     @staticmethod
     def _get_ssl_certs():

--- a/pylxd/tests/test_connection.py
+++ b/pylxd/tests/test_connection.py
@@ -53,7 +53,7 @@ class LXDInitConnectionTest(unittest.TestCase):
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
                 keyfile='/home/foo/.config/lxc/client.key',
-                ssl_version=ssl.PROTOCOL_TLSv1_2,
+                ssl_version=connection.DEFAULT_TLS_VERSION,
             )
 
     @mock.patch('os.environ', {'HOME': '/home/foo'})
@@ -71,7 +71,7 @@ class LXDInitConnectionTest(unittest.TestCase):
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
                 keyfile='/home/foo/.config/lxc/client.key',
-                ssl_version=ssl.PROTOCOL_TLSv1_2)
+                ssl_version=connection.DEFAULT_TLS_VERSION)
 
     @mock.patch('pylxd.connection.HTTPSConnection')
     @mock.patch('pylxd.connection.UnixHTTPConnection')


### PR DESCRIPTION
Ubuntu 14.04 doesnt have ssl.PROTOCOL_TLSv1_2, so check
to see if we hvae ssl.PROTOCOL_TLSv1_2 or ssl.PROTOCOL_TLSv1

Fixes issue #42

Signed-off-by: Chuck Short <chuck.short@canonical.com>