### PR TITLE
Detect SSL TLS version

### DIFF
--- a/pylxd/connection.py
+++ b/pylxd/connection.py
@@ -22,6 +22,22 @@ from pylxd import exceptions
 from pylxd import utils
 from six.moves import http_client
 
+if hasattr(ssl, 'SSLContext'):
+    # For Python >= 2.7.9 and Python 3.x
+    USE_STDLIB_SSL = True
+else:
+    # For Python 2.6 and <= 2.7.8
+    USE_STDLIB_SSL = False
+
+if not USE_STDLIB_SSL:
+    import OpenSSL.SSL
+
+# Detect SSL tls version
+if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+    DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
+else:
+    DEFAULT_TLS_VERSION = OpenSSL.SSL.TLSv1_2_METHOD
+
 
 class UnixHTTPConnection(http_client.HTTPConnection):
 
@@ -55,7 +71,7 @@ class HTTPSConnection(http_client.HTTPConnection):
         (cert_file, key_file) = self._get_ssl_certs()
         self.sock = ssl.wrap_socket(sock, certfile=cert_file,
                                     keyfile=key_file,
-                                    ssl_version=ssl.PROTOCOL_TLSv1_2)
+                                    ssl_version=DEFAULT_TLS_VERSION)
 
     @staticmethod
     def _get_ssl_certs():

--- a/pylxd/tests/test_connection.py
+++ b/pylxd/tests/test_connection.py
@@ -18,7 +18,6 @@ import mock
 from six.moves import cStringIO
 from six.moves import http_client
 import socket
-import ssl
 import unittest
 
 from pylxd import connection
@@ -53,7 +52,7 @@ class LXDInitConnectionTest(unittest.TestCase):
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
                 keyfile='/home/foo/.config/lxc/client.key',
-                ssl_version=ssl.PROTOCOL_TLSv1_2,
+                ssl_version=connection.DEFAULT_TLS_VERSION,
             )
 
     @mock.patch('os.environ', {'HOME': '/home/foo'})
@@ -71,7 +70,7 @@ class LXDInitConnectionTest(unittest.TestCase):
                 ms.return_value,
                 certfile='/home/foo/.config/lxc/client.crt',
                 keyfile='/home/foo/.config/lxc/client.key',
-                ssl_version=ssl.PROTOCOL_TLSv1_2)
+                ssl_version=connection.DEFAULT_TLS_VERSION)
 
     @mock.patch('pylxd.connection.HTTPSConnection')
     @mock.patch('pylxd.connection.UnixHTTPConnection')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pbr<2.0,>=1.6
 Babel>=1.3
 python-dateutil>=2.4.2
 six>=1.9.0
+pyOpenSSL


### PR DESCRIPTION
Ubuntu 14.04 doesnt have ssl.PROTOCOL_TLSv1_2, so check  to see if we have ssl.PROTOCOL_TLSv1_2 available otherwise use OpenSSL.SSL.TLSv1_2_METHOD.

Fixes issue #42
    
