### PR TITLE
Remove override of close() in WebSocketClient

### DIFF
--- a/pylxd/connection.py
+++ b/pylxd/connection.py
@@ -109,11 +109,6 @@ class WebSocketClient(websocket.WebSocketBaseClient):
         """Override the base class to store the incoming message."""
         self.messages.put(copy.deepcopy(message))
 
-    def close(self, code=1000, reason=''):
-        # NOTE(u_glide): Don't send closing frame because socket always
-        # terminated by the LXD
-        pass
-
     def closed(self, code, reason=None):
         # When the connection is closed, put a StopIteration
         # on the message queue to signal there's nothing left


### PR DESCRIPTION
Since 0.24 LXD doesn't terminate web socket and it should be closed by client via close() method.