### PR TITLE
The end is near

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "pypy"
 install: pip install -U -r requirements.txt -r test-requirements.txt
-before_script: flake8 --ignore=E123,E125
-script: ostestr --blacklist_file blacklist
+script:
+  - ostestr --blacklist_file blacklist
+  - flake8 --ignore=E123,E125

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.4"
-  - "pypy3"
 install: pip install -U -r requirements.txt -r test-requirements.txt
 script:
   - ostestr --blacklist_file blacklist

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
-  - "pypy"
+  - "pypy3"
 install: pip install -U -r requirements.txt -r test-requirements.txt
 script:
   - ostestr --blacklist_file blacklist

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
   - "3.4"
 install: pip install -U -r requirements.txt -r test-requirements.txt
 before_script: flake8 --ignore=E123,E125
-script: ostestr
+script: ostestr --blacklist_file blacklist

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ python:
   - "3.4"
 install: pip install -U -r requirements.txt -r test-requirements.txt
 script:
-  - ostestr --blacklist_file blacklist
+  - nosetests pylxd
   - flake8 --ignore=E123,E125

--- a/blacklist
+++ b/blacklist
@@ -1,0 +1,1 @@
+integration.*

--- a/examples/api_test.py
+++ b/examples/api_test.py
@@ -16,10 +16,10 @@
 
 import uuid
 
+from pylxd import api
+
 # Let's pick a random name, avoiding clashes
 CONTAINER_NAME = str(uuid.uuid1())
-
-from pylxd import api
 
 lxd = api.API()
 try:

--- a/integration/test_base.py
+++ b/integration/test_base.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import unittest
 
 from pylxd.api import LXD
@@ -91,7 +105,10 @@ class TestBaseAssumptions(unittest.TestCase):
         self.assertEqual(expected, json)
 
     def test_1_0_certificates_POST(self):
-        """POST to /1.0/certificates is allowed for everyone with a client certificate."""
+        """POST to /1.0/certificates is allowed for everyone.
+
+        ...with a client certificate.
+        """
         expected = {
             "type": "sync",
             "status": "Success",

--- a/integration/test_base.py
+++ b/integration/test_base.py
@@ -1,0 +1,109 @@
+import unittest
+
+from pylxd.api import LXD
+
+CERT = '''MIICATCCAWoCCQDejRDAWZlG0DANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJV
+UzETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMB4XDTE2MDExMzE0MTAyNFoXDTI2MDExMDE0MTAyNFowRTELMAkG
+A1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAv4bk
+u8i1q/5vl8VbSALC4Q2MHcyVgQ7I8RGnTZArbD5fGAhhvBXki2w2fo8eoaOV7hh0
+bAo+t7rn4RE39OQbdeyAdG62qkRug58eeUb0Qz2Zcg9CQ5vcbApElykHmMt2yXW3
+gxtPu0mqUQnUt2zs7/8okwtfc2SMZKpwrUrxDU8CAwEAATANBgkqhkiG9w0BAQsF
+AAOBgQA2c14J5FbxMFxTJuEjiIY1s4eJCW1XDC0SO2WRY3iz0fwKautLoOnZJOQk
+OZNzJlCVpZjpHeL847mz2ybtoFpUO45bWGg75W5gh4D2gmnG+FlCg2l3Tno1bMoS
+tTQu8yyFguWnWnCokzEovlKMR1YajPvndmzf7zRujcL2vKL5uA==
+'''
+
+
+class TestBaseAssumptions(unittest.TestCase):
+    """lxd makes some common base assumptions about the rest api."""
+
+    def setUp(self):
+        self.lxd = LXD('http+unix://%2Fvar%2Flib%2Flxd%2Funix.socket')
+
+    def test_root(self):
+        """GET to / is allowed for everyone (lists the API endpoints)."""
+        expected = {
+            'type': 'sync',
+            'status': 'Success',
+            'status_code': 200,
+            'metadata': ['/1.0']
+        }
+
+        result = self.lxd.get()
+
+        self.assertEqual(200, result.status_code)
+        self.assertEqual(expected, result.json())
+
+    def test_1_0(self):
+        """GET to /1.0 is allowed for everyone (but result varies)."""
+        expected = {
+            "type": "sync",
+            "status": "Success",
+            "status_code": 200,
+            "metadata": {
+                "api_compat": 1,
+                "auth": "trusted",
+                "config": {
+                    "images.remote_cache_expiry": "10"
+                },
+                "environment": {
+                    "addresses": [],
+                    "architectures": [2, 1],
+                    "driver": "lxc",
+                    "driver_version": "1.1.5",
+                    "kernel": "Linux",
+                    "kernel_architecture": "x86_64",
+                    "kernel_version": "4.2.0-19-generic",
+                    "server": "lxd",
+                    "server_pid": 7453,
+                    "server_version": "0.20",
+                    "storage": "dir",
+                    "storage_version": ""
+                }
+            }
+        }
+
+        result = self.lxd['1.0'].get()
+
+        self.assertEqual(200, result.status_code)
+        self.assertEqual(expected, result.json())
+
+    def test_1_0_images(self):
+        """GET to /1.0/images/* is allowed for everyone.
+
+        ...but only returns public images for unauthenticated users.
+        """
+        expected = {
+            "type": "sync",
+            "status": "Success",
+            "status_code": 200,
+            "metadata": []
+        }
+
+        result = self.lxd['1.0'].images.get()
+        json = result.json()
+        # metadata should exist, but its content varies.
+        json['metadata'] = []
+
+        self.assertEqual(200, result.status_code)
+        self.assertEqual(expected, json)
+
+    def test_1_0_certificates_POST(self):
+        """POST to /1.0/certificates is allowed for everyone with a client certificate."""
+        expected = {
+            "type": "sync",
+            "status": "Success",
+            "status_code": 200,
+            "metadata": {}
+        }
+
+        data = {
+            'type': 'client',
+            'certificate': CERT,
+        }
+        result = self.lxd['1.0'].certificates.post(json=data)
+
+        self.assertEqual(200, result.status_code)
+        self.assertEqual(expected, result.json())

--- a/pylxd/api.py
+++ b/pylxd/api.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import requests
+import requests_unixsocket
 
 from pylxd import certificate
 from pylxd import connection
@@ -46,9 +47,21 @@ class _APINode(object):
     def __getitem__(self, item):
         return self.__class__('{}/{}'.format(self._api_endpoint, item))
 
+    @property
+    def session(self):
+        if self._api_endpoint.startswith('http+unix://'):
+            return requests_unixsocket.Session()
+        else:
+            return requests
+
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        requests.get(self._api_endpoint, *args, **kwargs)
+        return self.session.get(self._api_endpoint, *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        """Perform an HTTP POST."""
+        return self.session.post(self._api_endpoint, *args, **kwargs)
+LXD = _APINode
 
 
 class API(object):

--- a/pylxd/api.py
+++ b/pylxd/api.py
@@ -26,7 +26,16 @@ from pylxd import profiles
 
 
 class _APINode(object):
-    """An api node object."""
+    """An api node object.
+
+    This class allows us to dynamically create request urls by expressing them
+    in python. For example:
+
+        >>> node = APINode('http://example.com/api')
+        >>> node.users[1].comments.get()
+
+    ...would make an HTTP GET request on http://example.com/api/users/1/comments.
+    """
 
     def __init__(self, api_endpoint):
         self._api_endpoint = api_endpoint
@@ -38,6 +47,7 @@ class _APINode(object):
         return self.__class__('{}/{}'.format(self._api_endpoint, item))
 
     def get(self, *args, **kwargs):
+        """Perform an HTTP GET."""
         requests.get(self._api_endpoint, *args, **kwargs)
 
 

--- a/pylxd/api.py
+++ b/pylxd/api.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import requests
+
 from pylxd import certificate
 from pylxd import connection
 from pylxd import container
@@ -21,6 +23,22 @@ from pylxd import image
 from pylxd import network
 from pylxd import operation
 from pylxd import profiles
+
+
+class _APINode(object):
+    """An api node object."""
+
+    def __init__(self, api_endpoint):
+        self._api_endpoint = api_endpoint
+
+    def __getattr__(self, name):
+        return self.__class__('{}/{}'.format(self._api_endpoint, name))
+
+    def __getitem__(self, item):
+        return self.__class__('{}/{}'.format(self._api_endpoint, item))
+
+    def get(self, *args, **kwargs):
+        requests.get(self._api_endpoint, *args, **kwargs)
 
 
 class API(object):

--- a/pylxd/api.py
+++ b/pylxd/api.py
@@ -35,7 +35,8 @@ class _APINode(object):
         >>> node = APINode('http://example.com/api')
         >>> node.users[1].comments.get()
 
-    ...would make an HTTP GET request on http://example.com/api/users/1/comments.
+    ...would make an HTTP GET request on
+    http://example.com/api/users/1/comments
     """
 
     def __init__(self, api_endpoint):

--- a/pylxd/tests/test_api.py
+++ b/pylxd/tests/test_api.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2015 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Tests for pylxd.api."""
+import unittest
+
+import mock
+
+from pylxd import api
+
+
+class Test_APINode(unittest.TestCase):
+    """Tests for pylxd.api._APINode."""
+    ROOT = 'http://lxd/api'
+
+    def test_getattr(self):
+        """`__getattr__` returns a nested node."""
+        lxd = api._APINode(self.ROOT)
+
+        self.assertEqual('{}/fake'.format(self.ROOT), lxd.fake._api_endpoint)
+
+    def test_getattr_nested(self):
+        """Nested objects return a more detailed path."""
+        lxd = api._APINode(self.ROOT)  # NOQA
+
+        self.assertEqual('{}/fake/path'.format(self.ROOT), lxd.fake.path._api_endpoint)
+
+    @mock.patch('pylxd.api.requests.get')
+    def test_get(self, _get):
+        """`get` will make a request to the smart url."""
+        lxd = api._APINode(self.ROOT)
+
+        lxd.fake.get()
+
+        _get.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+
+    def test_getitem(self):
+        """`__getitem__` enables dynamic url parts."""
+        lxd = api._APINode(self.ROOT)  # NOQA
+
+        self.assertEqual(
+            '{}/fake/path'.format(self.ROOT),
+            lxd.fake['path']._api_endpoint)
+
+    def test_getitem_integer(self):
+        """`__getitem__` with an integer allows dynamic integer url parts."""
+        lxd = api._APINode(self.ROOT)  # NOQA
+
+        self.assertEqual('{}/fake/0'.format(self.ROOT), lxd.fake[0]._api_endpoint)

--- a/pylxd/tests/test_api.py
+++ b/pylxd/tests/test_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Canonical Ltd
+# Copyright (c) 2016 Canonical Ltd
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -33,7 +33,9 @@ class Test_APINode(unittest.TestCase):
         """Nested objects return a more detailed path."""
         lxd = api._APINode(self.ROOT)  # NOQA
 
-        self.assertEqual('{}/fake/path'.format(self.ROOT), lxd.fake.path._api_endpoint)
+        self.assertEqual(
+            '{}/fake/path'.format(self.ROOT),
+            lxd.fake.path._api_endpoint)
 
     def test_getitem(self):
         """`__getitem__` enables dynamic url parts."""
@@ -47,7 +49,9 @@ class Test_APINode(unittest.TestCase):
         """`__getitem__` with an integer allows dynamic integer url parts."""
         lxd = api._APINode(self.ROOT)  # NOQA
 
-        self.assertEqual('{}/fake/0'.format(self.ROOT), lxd.fake[0]._api_endpoint)
+        self.assertEqual(
+            '{}/fake/0'.format(self.ROOT),
+            lxd.fake[0]._api_endpoint)
 
     @mock.patch('pylxd.api.requests.get')
     def test_get(self, _get):

--- a/pylxd/tests/test_api.py
+++ b/pylxd/tests/test_api.py
@@ -35,15 +35,6 @@ class Test_APINode(unittest.TestCase):
 
         self.assertEqual('{}/fake/path'.format(self.ROOT), lxd.fake.path._api_endpoint)
 
-    @mock.patch('pylxd.api.requests.get')
-    def test_get(self, _get):
-        """`get` will make a request to the smart url."""
-        lxd = api._APINode(self.ROOT)
-
-        lxd.fake.get()
-
-        _get.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
-
     def test_getitem(self):
         """`__getitem__` enables dynamic url parts."""
         lxd = api._APINode(self.ROOT)  # NOQA
@@ -57,3 +48,21 @@ class Test_APINode(unittest.TestCase):
         lxd = api._APINode(self.ROOT)  # NOQA
 
         self.assertEqual('{}/fake/0'.format(self.ROOT), lxd.fake[0]._api_endpoint)
+
+    @mock.patch('pylxd.api.requests.get')
+    def test_get(self, _get):
+        """`get` will make a request to the smart url."""
+        lxd = api._APINode(self.ROOT)
+
+        lxd.fake.get()
+
+        _get.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+
+    @mock.patch('pylxd.api.requests.post')
+    def test_post(self, _post):
+        """`post` will POST to the smart url."""
+        lxd = api._APINode(self.ROOT)
+
+        lxd.fake.post()
+
+        _post.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ six>=1.9.0
 pyOpenSSL>=0.14
 ws4py>=0.3.4
 requests==2.9.1
+requests-unixsocket==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,6 @@
-# The order of packages is significant, because pip processes them in the order
-# of appearance. Changing the order has an impact on the overall integration
-# process, which may cause wedges in the gate later.
-
 pbr>=1.6
-Babel>=1.3
 python-dateutil>=2.4.2
 six>=1.9.0
-pyOpenSSL>=0.14
 ws4py>=0.3.4
 requests==2.9.1
 requests-unixsocket==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dateutil>=2.4.2
 six>=1.9.0
 pyOpenSSL>=0.14
 ws4py>=0.3.4
+requests==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=1.8'],
+    setup_requires=['pbr>=1.8', 'requests>=2.9.1'],
     pbr=True)

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,9 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=1.8', 'requests>=2.9.1'],
+    setup_requires=[
+        'pbr>=1.8',
+        'requests>=2.9.1',
+        'requests-unixsocket==0.1.4',
+    ],
     pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,14 +1,4 @@
-# The order of packages is significant, because pip processes them in the order
-# of appearance. Changing the order has an impact on the overall integration
-# process, which may cause wedges in the gate later.
-
-hacking<0.11,>=0.10.0
-
-coverage>=3.6
 ddt>=0.7.0
-discover
-python-subunit>=0.0.18
-sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
-oslosphinx!=3.4.0,>=2.5.0 # Apache-2.0
-oslotest>=1.10.0 # Apache-2.0
-os-testr>=0.6.0
+nose>=1.3.7
+mock>=1.3.0
+flake8>=2.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,4 +11,4 @@ python-subunit>=0.0.18
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 oslosphinx!=3.4.0,>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0
-os-testr>=0.4.1
+os-testr>=0.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = ostestr
+commands = ostestr --blacklist_file blacklist
 
 [testenv:pep8]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,22 +10,13 @@ setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = ostestr --blacklist_file blacklist
+commands = nosetests pylxd
 
 [testenv:pep8]
 commands = flake8
 
-[testenv:venv]
-commands = {posargs}
-
-[testenv:cover]
-commands = python setup.py test --coverage --testr-args='{posargs}'
-
-[testenv:docs]
-commands = python setup.py build_sphinx
-
-[testenv:debug]
-commands = oslo_debug_helper {posargs}
+[testenv:integration]
+commands = nosetests integration
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
This is the start of a re-work of the LXD api client for python.

The next step, after this, is to go through the LXD spec itself and implement the client per the spec, thus making sure the client is spec'd properly, but also forcing LXD to have implemented the spec properly.

This code isn't currently being used yet. Once the full client is implemented, we'll deprecate the old code (which, we've recently learned, doesn't work at all on python3).