### PR TITLE
Fix six.PY34 into six.PY3

### DIFF
--- a/pylxd/deprecated/connection.py
+++ b/pylxd/deprecated/connection.py
@@ -50,7 +50,7 @@ class UnixHTTPConnection(http_client.HTTPConnection):
 
     def __init__(self, path, host='localhost', port=None, strict=None,
                  timeout=None):
-        if six.PY34:
+        if six.PY3:
             http_client.HTTPConnection.__init__(self, host, port=port,
                                                 timeout=timeout)
         else:
@@ -157,7 +157,7 @@ class LXDConnection(object):
         status = response.status
         raw_body = response.read()
         try:
-            if six.PY34:
+            if six.PY3:
                 body = json.loads(raw_body.decode())
             else:
                 body = json.loads(raw_body)

--- a/pylxd/deprecated/tests/test_connection.py
+++ b/pylxd/deprecated/tests/test_connection.py
@@ -25,7 +25,7 @@ from pylxd.deprecated import connection
 from pylxd.deprecated import exceptions
 from pylxd.deprecated.tests import annotated_data
 
-if six.PY34:
+if six.PY3:
     from io import BytesIO
 
 
@@ -36,7 +36,7 @@ class LXDInitConnectionTest(unittest.TestCase):
     @mock.patch.object(http_client.HTTPConnection, '__init__')
     def test_http_connection(self, mc, ms):
         conn = connection.UnixHTTPConnection('/', 'host', 1234)
-        if six.PY34:
+        if six.PY3:
             mc.assert_called_once_with(
                 conn, 'host', port=1234, timeout=None)
         else:
@@ -105,7 +105,7 @@ class FakeResponse(object):
 
     def __init__(self, status, data):
         self.status = status
-        if six.PY34:
+        if six.PY3:
             self.read = BytesIO(six.b(data)).read
         else:
             self.read = cStringIO(data).read


### PR DESCRIPTION
This otherwise fail to build in Jessie, and I'm adding this patch to the Debian package.