### PR TITLE
Python3 fixes

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -13,7 +13,11 @@
 #    under the License.
 import functools
 import os
-import urllib
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
 
 import requests
 import requests_unixsocket
@@ -115,7 +119,7 @@ class Client(object):
             else:
                 path = '/var/lib/lxd/unix.socket'
             self.api = _APINode('http+unix://{}'.format(
-                urllib.quote(path, safe='')))
+                quote(path, safe='')))
         self.api = self.api[version]
 
         self.containers = self.Containers(self)

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -70,7 +70,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
     def __init__(self, **kwargs):
         super(Container, self).__init__()
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
     def reload(self):
@@ -79,7 +79,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         if response.status_code == 404:
             raise NameError(
                 'Container named "{}" has gone away'.format(self.name))
-        for key, value in response.json()['metadata'].iteritems():
+        for key, value in six.iteritems(response.json()['metadata']):
             setattr(self, key, value)
 
     def update(self, wait=False):
@@ -124,7 +124,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
     def state(self):
         state = ContainerState()
         response = self._client.api.containers[self.name].state.get()
-        for key, value in response.json()['metadata'].iteritems():
+        for key, value in six.iteritems(response.json()['metadata']):
             setattr(state, key, value)
         return state
 

--- a/pylxd/containerState.py
+++ b/pylxd/containerState.py
@@ -12,9 +12,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import six
+
 
 class ContainerState():
-
     def __init__(self, **kwargs):
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import hashlib
+import six
 
 from pylxd import mixin
 from pylxd.operation import Operation
@@ -65,7 +66,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
 
     def __init__(self, **kwargs):
         super(Image, self).__init__()
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
     def update(self):

--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import six
+
 
 class Operation(object):
     """A LXD operation."""
@@ -37,7 +39,7 @@ class Operation(object):
 
     def __init__(self, **kwargs):
         super(Operation, self).__init__()
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
     def wait(self):

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import six
 from pylxd import mixin
 
 
@@ -54,7 +55,7 @@ class Profile(mixin.Marshallable):
 
     def __init__(self, **kwargs):
         super(Profile, self).__init__()
-        for key, value in kwargs.iteritems():
+        for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
     def update(self):


### PR DESCRIPTION
I needed those two changes to get lxc-to-lxd working with the non-deprecated pylxd API.

I'm reasonably sure the the quote commit is properly backward compatible, I'm not so sure about the iteritems() one though, if it's not, we'll need a wrapper function which takes a dict and calls the right thing depending on python version.