### PR TITLE
Fix CI + error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-install: pip install -U -r requirements.txt -r test-requirements.txt
+- "3.5"
+env:
+  matrix:
+  - TOXENV=py27
+  - TOXENV=py3
+  - TOXENV=pep8
+  # - TOXENV=integration # requires a remote lxd setup
+
+install:
+- travis_retry pip install tox
 script:
-  - nosetests pylxd
-  - flake8 --ignore=E123,E125
+- tox
+- test -d .tox/$TOXENV/log && cat .tox/$TOXENV/log/*.log || true
+cache:
+  directories:
+  - .tox/$TOXENV
+  - $HOME/.cache/pip

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -40,7 +40,7 @@ class TestContainers(IntegrationTestCase):
         """Creates and returns a new container."""
         config = {
             'name': 'an-container',
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': True,
             'config': {'limits.cpu': '2'},

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -41,6 +41,20 @@ class TestContainers(IntegrationTestCase):
         )
         self.assertEqual(name, containers[0].name)
 
+    def test_create_failure(self):
+        config = {
+            'name': 'an-container',
+            'architecture': '2',
+            'profiles': ['default'],
+            'ephemeral': True,
+            'config': {'limits.cpu': '2'},
+            'source': {'type': 'image',
+                       'alias': self.generate_object_name()},
+        }
+
+        with self.assertRaises(RuntimeError):
+            self.client.containers.create(config, wait=True)
+
     def test_create(self):
         """Creates and returns a new container."""
         config = {

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -28,12 +28,17 @@ class TestContainers(IntegrationTestCase):
 
     def test_all(self):
         """A list of all containers is returned."""
+        containers_before_create = self.client.containers.all()
+
         name = self.create_container()
         self.addCleanup(self.delete_container, name)
 
         containers = self.client.containers.all()
 
-        self.assertEqual(1, len(containers))
+        self.assertEqual(
+            len(containers_before_create) + 1,
+            len(containers)
+        )
         self.assertEqual(name, containers[0].name)
 
     def test_create(self):

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -98,15 +98,15 @@ class TestContainer(IntegrationTestCase):
         # to test what we need.
         self.container.start(wait=True)
 
-        self.assertEqual('Running', self.container.status['status'])
+        self.assertEqual('Running', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Running', container.status['status'])
+        self.assertEqual('Running', container.status)
 
         self.container.stop(wait=True)
 
-        self.assertEqual('Stopped', self.container.status['status'])
+        self.assertEqual('Stopped', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Stopped', container.status['status'])
+        self.assertEqual('Stopped', container.status)
 
     def test_snapshot(self):
         """A container snapshot is made, renamed, and deleted."""

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -13,6 +13,7 @@
 #    under the License.
 import uuid
 import unittest
+import os
 
 from pylxd.client import Client
 from integration.busybox import create_busybox_image
@@ -23,7 +24,7 @@ class IntegrationTestCase(unittest.TestCase):
 
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
-        self.client = Client()
+        self.client = Client(os.environ.get('LXD_ENDPOINT', None))
         self.lxd = self.client.api
 
     def generate_object_name(self):

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -37,7 +37,7 @@ class IntegrationTestCase(unittest.TestCase):
         name = self.generate_object_name()
         machine = {
             'name': name,
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': False,
             'config': {'limits.cpu': '2'},

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -24,7 +24,12 @@ class IntegrationTestCase(unittest.TestCase):
 
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
-        self.client = Client(os.environ.get('LXD_ENDPOINT', None))
+        self.client = Client(
+            os.environ.get('LXD_ENDPOINT', None),
+            insecure='LXD_INSECURE' in os.environ,
+            client_crt=os.environ.get('LXD_CLIENT_CRT', None),
+            client_key=os.environ.get('LXD_CLIENT_KEY', None)
+        )
         self.lxd = self.client.api
 
     def generate_object_name(self):

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -21,6 +21,7 @@ except ImportError:
 
 import requests
 import requests_unixsocket
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from pylxd.container import Container
 from pylxd.image import Image
@@ -45,6 +46,17 @@ class _APINode(object):
 
     def __init__(self, api_endpoint):
         self._api_endpoint = api_endpoint
+        self._requests_kwargs = {}
+
+        client_crt = os.environ.get('LXD_CLIENT_CRT', None)
+        client_key = os.environ.get('LXD_CLIENT_KEY', None)
+
+        if client_crt and client_key:
+            self._requests_kwargs['cert'] = (client_crt, client_key)
+
+        if os.environ.get('LXD_INSECURE', False):
+            self._requests_kwargs['verify'] = False
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
     def __getattr__(self, name):
         return self.__class__('{}/{}'.format(self._api_endpoint, name))
@@ -61,18 +73,22 @@ class _APINode(object):
 
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
+        kwargs.update(self._requests_kwargs)
         return self.session.get(self._api_endpoint, *args, **kwargs)
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
+        kwargs.update(self._requests_kwargs)
         return self.session.post(self._api_endpoint, *args, **kwargs)
 
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
+        kwargs.update(self._requests_kwargs)
         return self.session.put(self._api_endpoint, *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
+        kwargs.update(self._requests_kwargs)
         return self.session.delete(self._api_endpoint, *args, **kwargs)
 
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -44,25 +44,21 @@ class _APINode(object):
     http://example.com/api/users/1/comments
     """
 
-    def __init__(self, api_endpoint):
+    def __init__(self, api_endpoint, default_kwargs=None):
         self._api_endpoint = api_endpoint
-        self._requests_kwargs = {}
+        self._default_kwargs = default_kwargs or {}
 
-        client_crt = os.environ.get('LXD_CLIENT_CRT', None)
-        client_key = os.environ.get('LXD_CLIENT_KEY', None)
-
-        if client_crt and client_key:
-            self._requests_kwargs['cert'] = (client_crt, client_key)
-
-        if os.environ.get('LXD_INSECURE', False):
-            self._requests_kwargs['verify'] = False
-            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    def create_child(self, child):
+        return self.__class__(
+            '{}/{}'.format(self._api_endpoint, child),
+            self._default_kwargs,
+        )
 
     def __getattr__(self, name):
-        return self.__class__('{}/{}'.format(self._api_endpoint, name))
+        return self.create_child(name)
 
     def __getitem__(self, item):
-        return self.__class__('{}/{}'.format(self._api_endpoint, item))
+        return self.create_child(item)
 
     @property
     def session(self):
@@ -71,25 +67,44 @@ class _APINode(object):
         else:
             return requests
 
+    def request(self, method, *args, **kwargs):
+        kwargs.update(self._default_kwargs)
+
+        response = self.session.request(
+            method.upper(),
+            self._api_endpoint,
+            *args,
+            **kwargs
+        )
+
+        if int(response.status_code) >= 500:
+            # A bit rough for now, let's see how it looks like in bug reports
+            # and refine over time.
+            raise RuntimeError(
+                self._api_endpoint,
+                args,
+                kwargs,
+                response.status_code,
+                response.json()
+            )
+
+        return response
+
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        kwargs.update(self._requests_kwargs)
-        return self.session.get(self._api_endpoint, *args, **kwargs)
+        return self.request('GET', *args, **kwargs)
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
-        kwargs.update(self._requests_kwargs)
-        return self.session.post(self._api_endpoint, *args, **kwargs)
+        return self.request('POST', *args, **kwargs)
 
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
-        kwargs.update(self._requests_kwargs)
-        return self.session.put(self._api_endpoint, *args, **kwargs)
+        return self.request('PUT', *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
-        kwargs.update(self._requests_kwargs)
-        return self.session.delete(self._api_endpoint, *args, **kwargs)
+        return self.request('DELETE', *args, **kwargs)
 
 
 class Client(object):
@@ -125,9 +140,23 @@ class Client(object):
             self.all = functools.partial(Profile.all, client)
             self.create = functools.partial(Profile.create, client)
 
-    def __init__(self, endpoint=None, version='1.0'):
+    def __init__(self, endpoint=None, version='1.0',
+                 client_crt=None, client_key=None, insecure=False):
         if endpoint is not None:
             self.api = _APINode(endpoint)
+
+            # This should be made constructor arguments at some point.
+            if client_crt and client_key:
+                self.api._default_kwargs['cert'] = (client_crt, client_key)
+
+            if insecure:
+                self.api._default_kwargs['verify'] = False
+
+            # Since disabling the warning is global, we can't and should not
+            # try to do this per-instance.
+            if 'LXD_INSECURE' in os.environ:
+                requests.packages.urllib3.disable_warnings(
+                    InsecureRequestWarning)
         else:
             if 'LXD_DIR' in os.environ:
                 path = os.path.join(
@@ -136,6 +165,7 @@ class Client(object):
                 path = '/var/lib/lxd/unix.socket'
             self.api = _APINode('http+unix://{}'.format(
                 quote(path, safe='')))
+
         self.api = self.api[version]
 
         self.containers = self.Containers(self)

--- a/pylxd/deprecated/tests/test_client.py
+++ b/pylxd/deprecated/tests/test_client.py
@@ -53,38 +53,50 @@ class Test_APINode(unittest.TestCase):
             '{}/fake/0'.format(self.ROOT),
             lxd.fake[0]._api_endpoint)
 
-    @mock.patch('pylxd.client.requests.get')
-    def test_get(self, _get):
+    @mock.patch('pylxd.client.requests.request')
+    def test_get(self, _request):
         """`get` will make a request to the smart url."""
         lxd = client._APINode(self.ROOT)
 
         lxd.fake.get()
 
-        _get.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+        _request.assert_called_once_with(
+            'GET',
+            '{}/{}'.format(self.ROOT, 'fake')
+        )
 
-    @mock.patch('pylxd.client.requests.post')
-    def test_post(self, _post):
+    @mock.patch('pylxd.client.requests.request')
+    def test_post(self, _request):
         """`post` will POST to the smart url."""
         lxd = client._APINode(self.ROOT)
 
         lxd.fake.post()
 
-        _post.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+        _request.assert_called_once_with(
+            'POST',
+            '{}/{}'.format(self.ROOT, 'fake')
+        )
 
-    @mock.patch('pylxd.client.requests.put')
-    def test_put(self, _put):
+    @mock.patch('pylxd.client.requests.request')
+    def test_put(self, _request):
         """`put` will PUT to the smart url."""
         lxd = client._APINode(self.ROOT)
 
         lxd.fake.put()
 
-        _put.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+        _request.assert_called_once_with(
+            'PUT',
+            '{}/{}'.format(self.ROOT, 'fake')
+        )
 
-    @mock.patch('pylxd.client.requests.delete')
-    def test_delete(self, _delete):
+    @mock.patch('pylxd.client.requests.request')
+    def test_delete(self, _request):
         """`delete` will DELETE to the smart url."""
         lxd = client._APINode(self.ROOT)
 
         lxd.fake.delete()
 
-        _delete.assert_called_once_with('{}/{}'.format(self.ROOT, 'fake'))
+        _request.assert_called_once_with(
+            'DELETE',
+            '{}/{}'.format(self.ROOT, 'fake')
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands = nosetests pylxd
 
 [testenv:pep8]
 commands = flake8
+deps = flake8
 
 [testenv:integration]
 passenv = HOME

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,11 @@ commands = nosetests pylxd
 commands = flake8
 
 [testenv:integration]
-commands = nosetests integration
+passenv = HOME
+whitelist_externals = lxc
+commands =
+    lxc image import https://dl.stgraber.org/lxd --alias busybox
+    nosetests integration
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
The current state of pylxd CI is: only "deprecated" unit tests are run by travis.

As a result, some tests were broken, and we wouldn't know how to make other ones to pass (import a busybox image !).

The purpose of this PR is to stabilize the situation by:

- fixing integration tests,
- making them runnable with tox -e integration,
- making them runnable against an LXD instance on the network, for travis.

In addition, this PR fixes the blockers we have in ansible/ansible-modules-extras#2208