### PR TITLE
Fix integration test

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -40,7 +40,7 @@ class TestContainers(IntegrationTestCase):
         """Creates and returns a new container."""
         config = {
             'name': 'an-container',
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': True,
             'config': {'limits.cpu': '2'},

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -28,12 +28,17 @@ class TestContainers(IntegrationTestCase):
 
     def test_all(self):
         """A list of all containers is returned."""
+        containers_before_create = self.client.containers.all()
+
         name = self.create_container()
         self.addCleanup(self.delete_container, name)
 
         containers = self.client.containers.all()
 
-        self.assertEqual(1, len(containers))
+        self.assertEqual(
+            len(containers_before_create) + 1,
+            len(containers)
+        )
         self.assertEqual(name, containers[0].name)
 
     def test_create(self):

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -98,15 +98,15 @@ class TestContainer(IntegrationTestCase):
         # to test what we need.
         self.container.start(wait=True)
 
-        self.assertEqual('Running', self.container.status['status'])
+        self.assertEqual('Running', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Running', container.status['status'])
+        self.assertEqual('Running', container.status)
 
         self.container.stop(wait=True)
 
-        self.assertEqual('Stopped', self.container.status['status'])
+        self.assertEqual('Stopped', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Stopped', container.status['status'])
+        self.assertEqual('Stopped', container.status)
 
     def test_snapshot(self):
         """A container snapshot is made, renamed, and deleted."""

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -37,7 +37,7 @@ class IntegrationTestCase(unittest.TestCase):
         name = self.generate_object_name()
         machine = {
             'name': name,
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': False,
             'config': {'limits.cpu': '2'},

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,11 @@ commands = nosetests pylxd
 commands = flake8
 
 [testenv:integration]
-commands = nosetests integration
+passenv = HOME
+whitelist_externals = lxc
+commands =
+    lxc image import https://dl.stgraber.org/lxd --alias busybox
+    nosetests integration
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
The purpose of this PR is only to fix `tox -e integration` or `nosetests integration` if you have a busybox image in your lxd.