### PR TITLE
Container creation failure handling

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -31,3 +31,9 @@ Profile
 
 .. autoclass:: pylxd.profile.Profile
    :members:
+
+Exceptions
+----------
+
+.. automodule:: pylxd.exceptions
+   :members:

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -40,7 +40,7 @@ class TestContainers(IntegrationTestCase):
         """Creates and returns a new container."""
         config = {
             'name': 'an-container',
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': True,
             'config': {'limits.cpu': '2'},

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -28,12 +28,17 @@ class TestContainers(IntegrationTestCase):
 
     def test_all(self):
         """A list of all containers is returned."""
+        containers_before_create = self.client.containers.all()
+
         name = self.create_container()
         self.addCleanup(self.delete_container, name)
 
         containers = self.client.containers.all()
 
-        self.assertEqual(1, len(containers))
+        self.assertEqual(
+            len(containers_before_create) + 1,
+            len(containers)
+        )
         self.assertEqual(name, containers[0].name)
 
     def test_create(self):

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -13,6 +13,8 @@
 #    under the License.
 from integration.testing import IntegrationTestCase
 
+from pylxd.exceptions import ContainerCreationFailure
+
 
 class TestContainers(IntegrationTestCase):
     """Tests for `Client.containers`"""
@@ -57,6 +59,13 @@ class TestContainers(IntegrationTestCase):
         container = self.client.containers.create(config, wait=True)
 
         self.assertEqual(config['name'], container.name)
+
+    def test_create_failure(self):
+        with self.assertRaises(ContainerCreationFailure) as e:
+            self.client.containers.create(dict(name=self.id()))
+
+        # Check that we have the response object
+        self.assertEqual(e.exception.response.status_code, 400)
 
 
 class TestContainer(IntegrationTestCase):

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -98,15 +98,15 @@ class TestContainer(IntegrationTestCase):
         # to test what we need.
         self.container.start(wait=True)
 
-        self.assertEqual('Running', self.container.status['status'])
+        self.assertEqual('Running', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Running', container.status['status'])
+        self.assertEqual('Running', container.status)
 
         self.container.stop(wait=True)
 
-        self.assertEqual('Stopped', self.container.status['status'])
+        self.assertEqual('Stopped', self.container.status)
         container = self.client.containers.get(self.container.name)
-        self.assertEqual('Stopped', container.status['status'])
+        self.assertEqual('Stopped', container.status)
 
     def test_snapshot(self):
         """A container snapshot is made, renamed, and deleted."""

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -37,7 +37,7 @@ class IntegrationTestCase(unittest.TestCase):
         name = self.generate_object_name()
         machine = {
             'name': name,
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': False,
             'config': {'limits.cpu': '2'},

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -16,6 +16,7 @@ import six
 
 from pylxd import mixin
 from pylxd.containerState import ContainerState
+from pylxd.exceptions import ContainerCreationFailure
 from pylxd.operation import Operation
 
 
@@ -61,11 +62,23 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
     @classmethod
     def create(cls, client, config, wait=False):
-        """Create a new container config."""
+        """Create a new container config test.
+
+        :param client: Instance of :class:`~pylxd.client.Client`.
+        :param config: Dict to pass to the API.
+        :param wait: Whether to wait for creation to complete or not.
+        :returns: :class:`~pylxd.container.Container`.
+        :raises: :class:`~pylxd.exceptions.ContainerCreationFailure`
+        """
         response = client.api.containers.post(json=config)
 
+        data = response.json()
+
+        if data.get('type', None) == 'error':
+            raise ContainerCreationFailure(response)
+
         if wait:
-            Operation.wait_for_operation(client, response.json()['operation'])
+            Operation.wait_for_operation(client, data['operation'])
         return cls(name=config['name'])
 
     def __init__(self, **kwargs):

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -1,0 +1,14 @@
+class PylxdException(Exception):
+    """Base exception for all exceptions of this module."""
+
+
+class ContainerCreationFailure(PylxdException):
+    """Raised when creating a container has failed."""
+
+    def __init__(self, response):
+        self.response = response
+
+        super(ContainerCreationFailure, self).__init__(
+            response.status_code,
+            response.json()
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,11 @@ commands = nosetests pylxd
 commands = flake8
 
 [testenv:integration]
-commands = nosetests integration
+passenv = HOME
+whitelist_externals = lxc
+commands =
+    lxc image import https://dl.stgraber.org/lxd --alias busybox
+    nosetests integration
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
This is a simple PoC of how we could handle container creation. It's tested in integration, so it requires integration tests to pass ( #87 does just that ). So please, close your eyes on any commit that is NOT 673845c in this PR :)

What do you think ? Would that approach be fine ? Perhaps we could have have unit tests in addition to integration tests too ?