### PR TITLE
Setup LXD before running integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,11 @@ commands = nosetests pylxd
 commands = flake8
 
 [testenv:integration]
-commands = nosetests integration
+passenv = HOME
+whitelist_externals = lxc
+commands =
+    lxc image import https://dl.stgraber.org/lxd --alias busybox
+    nosetests integration
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
The busybox image is necessary for test_containers.