### PR TITLE
Make architecture a string type

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -40,7 +40,7 @@ class TestContainers(IntegrationTestCase):
         """Creates and returns a new container."""
         config = {
             'name': 'an-container',
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': True,
             'config': {'limits.cpu': '2'},

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -37,7 +37,7 @@ class IntegrationTestCase(unittest.TestCase):
         name = self.generate_object_name()
         machine = {
             'name': name,
-            'architecture': 2,
+            'architecture': '2',
             'profiles': ['default'],
             'ephemeral': False,
             'config': {'limits.cpu': '2'},


### PR DESCRIPTION
Fixes:

    {u'type': u'error', u'error_code': 400, u'error': u'json: cannot unmarshal number into Go value of type string'}