### PR TITLE
Fix #97: improvements for container creation failure

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -31,3 +31,9 @@ Profile
 
 .. autoclass:: pylxd.profile.Profile
    :members:
+
+Exceptions
+----------
+
+.. automodule:: pylxd.exceptions
+   :members:

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -13,6 +13,8 @@
 #    under the License.
 from integration.testing import IntegrationTestCase
 
+from pylxd.exceptions import ContainerCreationFailure
+
 
 class TestContainers(IntegrationTestCase):
     """Tests for `Client.containers`"""
@@ -52,6 +54,13 @@ class TestContainers(IntegrationTestCase):
         container = self.client.containers.create(config, wait=True)
 
         self.assertEqual(config['name'], container.name)
+
+    def test_create_failure(self):
+        with self.assertRaises(ContainerCreationFailure) as e:
+            self.client.containers.create(dict(name=self.id()))
+
+        # Check that we have the response object
+        self.assertEqual(e.exception.response.status_code, 400)
 
 
 class TestContainer(IntegrationTestCase):

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -16,6 +16,7 @@ import six
 
 from pylxd import mixin
 from pylxd.containerState import ContainerState
+from pylxd.exceptions import ContainerCreationFailure
 from pylxd.operation import Operation
 
 
@@ -61,11 +62,19 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
     @classmethod
     def create(cls, client, config, wait=False):
-        """Create a new container config."""
+        """Create a new container config.
+
+        :param client: Instance of :class:`~pylxd.client.Client`.
+        :param config: Dict to pass to the API.
+        :param wait: Whether to wait for creation to complete or not.
+        :returns: :class:`~pylxd.container.Container`.
+        :raises: :class:`~pylxd.exceptions.ContainerCreationFailure`
+        """
         response = client.api.containers.post(json=config)
 
         if response.status_code != 202:
-            raise RuntimeError('Error creating instance')
+            raise ContainerCreationFailure(response)
+
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])
         return cls(name=config['name'], _client=client)

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -1,0 +1,14 @@
+class PylxdException(Exception):
+    """Base exception for all exceptions of this module."""
+
+
+class ContainerCreationFailure(PylxdException):
+    """Raised when creating a container has failed."""
+
+    def __init__(self, response):
+        self.response = response
+
+        super(ContainerCreationFailure, self).__init__(
+            response.status_code,
+            response.json()
+        )

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -3,6 +3,14 @@ import json
 
 def containers_POST(request, context):
     context.status_code = 202
+    if request.json()['name'] == 'fake-fail':
+        response_text = json.dumps({
+            'type': 'error',
+            'error_code': 400,
+            'error': u'unknown source type'
+        })
+        context.status_code = 400
+        return response_text
     return json.dumps({'operation': 'operation-abc'})
 
 

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -1,4 +1,5 @@
 from pylxd import container
+from pylxd.exceptions import ContainerCreationFailure
 from pylxd.tests import testing
 
 
@@ -34,6 +35,16 @@ class TestContainer(testing.PyLXDTestCase):
             self.client, config, wait=True)
 
         self.assertEqual(config['name'], an_new_container.name)
+
+    def test_create_failure(self):
+        """Container creation API responds with an error."""
+        config = {'name': 'fake-fail'}
+
+        with self.assertRaises(ContainerCreationFailure) as e:
+            container.Container.create(self.client, config, wait=True)
+
+        # Check that we have the response object
+        self.assertEqual(e.exception.response.status_code, 400)
 
     def test_reload(self):
         """A reload updates the properties of a container."""


### PR DESCRIPTION
Enables routing raised module-specific exceptions based on their type:

```
try:
    client.containers.create(dict(name='foo'))
except ContainerCreationFailure:
    print "Something went creating the container"
except:
    print "Something unknown went wrong, but the container was created"
```

And also stuff with the http response such as:

```
try:
    client.containers.create(dict(name='foo'))
except ContainerCreationError as e:
    print "Server did not create the container, details: ", e.response.json()
```