### PR TITLE
Verify client connection

### DIFF
--- a/pylxd/__init__.py
+++ b/pylxd/__init__.py
@@ -17,3 +17,4 @@ import pbr.version
 __version__ = pbr.version.VersionInfo('pylxd').version_string()
 
 from pylxd.deprecated import api  # NOQA
+from pylxd.client import Client  # NOQA

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -22,6 +22,7 @@ except ImportError:
 import requests
 import requests_unixsocket
 
+from pylxd import exceptions
 from pylxd.container import Container
 from pylxd.image import Image
 from pylxd.operation import Operation
@@ -201,6 +202,15 @@ class Client(object):
             self.api = _APINode('http+unix://{}'.format(
                 quote(path, safe='')))
         self.api = self.api[version]
+
+        # Verify the connection is valid.
+        try:
+            response = self.api.get()
+            if response.status_code != 200:
+                raise exceptions.ClientConnectionFailed()
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.InvalidURL):
+            raise exceptions.ClientConnectionFailed()
 
         self.containers = self.Containers(self)
         self.images = self.Images(self)

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -1,0 +1,2 @@
+class ClientConnectionFailed(Exception):
+    """An exception raised when the Client connection fails."""

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -36,6 +36,13 @@ def profile_GET(request, context):
 
 
 RULES = [
+    # General service endpoints
+    {
+        'text': '',
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0$',
+    },
+
     # Containers
     {
         'text': json.dumps({'metadata': [


### PR DESCRIPTION
The client init will raise an exception if the endpoint isn't accessible. This fixes one of the two issues I've discovered while trying to sort out what's going on with my local lxd install.