### PR TITLE
Allow specification of devices in a profile

### DIFF
--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -44,11 +44,12 @@ class Profile(mixin.Marshallable):
         return profiles
 
     @classmethod
-    def create(cls, client, name, config):
+    def create(cls, client, name, config, devices={}):
         """Create a profile."""
         client.api.profiles.post(json={
             'name': name,
-            'config': config
+            'config': config,
+            'devices': devices
             })
 
         return cls.get(client, name)

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -14,7 +14,7 @@ class TestProfile(testing.PyLXDTestCase):
     def test_create(self):
         """A new profile is created."""
         an_profile = profile.Profile.create(
-            self.client, name='an-new-profile', config={})
+            self.client, name='an-new-profile', config={}, devices={})
 
         self.assertIsInstance(an_profile, profile.Profile)
         self.assertEqual('an-new-profile', an_profile.name)


### PR DESCRIPTION
Currently its not possible to  specify devices when creating a LXD profile. This is required so we can attach
disks, network interfaces, etc in nova-lxd,

Signed-off-by: Chuck Short <chuck.short@canonical.com>