### PR TITLE
Add more exceptions to the API

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -14,7 +14,7 @@
 
 import six
 
-from pylxd import mixin
+from pylxd import exceptions, mixin
 from pylxd.containerState import ContainerState
 from pylxd.operation import Operation
 
@@ -38,7 +38,8 @@ class Container(mixin.Waitable, mixin.Marshallable):
         response = client.api.containers[name].get()
 
         if response.status_code == 404:
-            raise NameError('No container named "{}"'.format(name))
+            raise exceptions.NotFound(
+                'No container named "{}"'.format(name))
         container = cls(_client=client, **response.json()['metadata'])
         return container
 

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -66,7 +66,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         response = client.api.containers.post(json=config)
 
         if response.status_code != 202:
-            raise RuntimeError('Error creating instance')
+            raise exceptions.CreateFailed()
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])
         return cls(name=config['name'], _client=client)

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -38,8 +38,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         response = client.api.containers[name].get()
 
         if response.status_code == 404:
-            raise exceptions.NotFound(
-                'No container named "{}"'.format(name))
+            raise exceptions.NotFound(response.json())
         container = cls(_client=client, **response.json()['metadata'])
         return container
 
@@ -66,7 +65,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         response = client.api.containers.post(json=config)
 
         if response.status_code != 202:
-            raise exceptions.CreateFailed()
+            raise exceptions.CreateFailed(response.json())
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])
         return cls(name=config['name'], _client=client)

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -4,3 +4,7 @@ class ClientConnectionFailed(Exception):
 
 class NotFound(Exception):
     """Generic get failure exception."""
+
+
+class CreateFailed(Exception):
+    """Generic create failure exception."""

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -1,2 +1,6 @@
 class ClientConnectionFailed(Exception):
     """An exception raised when the Client connection fails."""
+
+
+class NotFound(Exception):
+    """Generic get failure exception."""

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -2,9 +2,23 @@ class ClientConnectionFailed(Exception):
     """An exception raised when the Client connection fails."""
 
 
-class NotFound(Exception):
+class _LXDAPIException(Exception):
+    """A LXD API Exception.
+
+    An exception representing an issue in the LXD API. It
+    contains the error information returned from LXD.
+
+    DO NOT CATCH THIS EXCEPTION DIRECTLY.
+    """
+
+    def __init__(self, data):
+        self.data = data
+        self.message = self.data.get('error')
+
+
+class NotFound(_LXDAPIException):
     """Generic get failure exception."""
 
 
-class CreateFailed(Exception):
+class CreateFailed(_LXDAPIException):
     """Generic create failure exception."""

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -33,7 +33,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
         response = client.api.images[fingerprint].get()
 
         if response.status_code == 404:
-            raise exceptions.NotFound()
+            raise exceptions.NotFound(response.json())
         image = Image(_client=client, **response.json()['metadata'])
         return image
 
@@ -60,7 +60,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
             data=image_data, headers=headers)
 
         if response.status_code != 202:
-            raise exceptions.CreateFailed()
+            raise exceptions.CreateFailed(response.json())
 
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import six
-from pylxd import mixin
+from pylxd import exceptions, mixin
 
 
 class Profile(mixin.Marshallable):
@@ -29,7 +29,7 @@ class Profile(mixin.Marshallable):
         response = client.api.profiles[name].get()
 
         if response.status_code == 404:
-            raise NameError('No profile with name "{}"'.format(name))
+            raise exceptions.NotFound()
         return cls(_client=client, **response.json()['metadata'])
 
     @classmethod
@@ -46,10 +46,13 @@ class Profile(mixin.Marshallable):
     @classmethod
     def create(cls, client, name, config):
         """Create a profile."""
-        client.api.profiles.post(json={
+        request = client.api.profiles.post(json={
             'name': name,
             'config': config
             })
+
+        if request.status_code is not 202:
+            raise exceptions.CreateFailed()
 
         return cls.get(client, name)
 

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -29,7 +29,7 @@ class Profile(mixin.Marshallable):
         response = client.api.profiles[name].get()
 
         if response.status_code == 404:
-            raise exceptions.NotFound()
+            raise exceptions.NotFound(response.json())
         return cls(_client=client, **response.json()['metadata'])
 
     @classmethod
@@ -46,13 +46,13 @@ class Profile(mixin.Marshallable):
     @classmethod
     def create(cls, client, name, config):
         """Create a profile."""
-        request = client.api.profiles.post(json={
+        response = client.api.profiles.post(json={
             'name': name,
             'config': config
             })
 
-        if request.status_code is not 202:
-            raise exceptions.CreateFailed()
+        if response.status_code is not 202:
+            raise exceptions.CreateFailed(response.json())
 
         return cls.get(client, name)
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -23,6 +23,16 @@ def container_DELETE(request, context):
     return json.dumps({'operation': 'operation-abc'})
 
 
+def images_POST(request, context):
+    context.status_code = 202
+    return json.dumps({'metadata': {}})
+
+
+def profiles_POST(request, context):
+    context.status_code = 202
+    return json.dumps({'metadata': {}})
+
+
 def profile_GET(request, context):
     name = request.path.split('/')[-1]
     if name in ('an-profile', 'an-new-profile'):
@@ -86,7 +96,7 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/images$',
     },
     {
-        'text': json.dumps({'metadata': {}}),
+        'text': images_POST,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/images$',
     },
@@ -109,6 +119,7 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/profiles$',
     },
     {
+        'text': profiles_POST,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/profiles$',
     },

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -6,18 +6,6 @@ def containers_POST(request, context):
     return json.dumps({'operation': 'operation-abc'})
 
 
-def container_GET(request, context):
-    if request.path.endswith('an-container'):
-        response_text = json.dumps({'metadata': {
-            'name': 'an-container',
-            'ephemeral': True,
-        }})
-        context.status_code = 200
-        return response_text
-    else:
-        context.status_code = 404
-
-
 def container_DELETE(request, context):
     context.status_code = 202
     return json.dumps({'operation': 'operation-abc'})
@@ -67,7 +55,10 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/containers$',
     },
     {
-        'text': container_GET,
+        'text': json.dumps({'metadata': {
+            'name': 'an-container',
+            'ephemeral': True,
+        }}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
     },

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -36,6 +36,21 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertEqual(config['name'], an_new_container.name)
 
+    def test_create_failed(self):
+        """If the container creation fails, CreateFailed is raised."""
+        def create_fail(request, context):
+            context.status_code = 500
+        self.add_rule({
+            'text': create_fail,
+            'method': 'POST',
+            'url': r'^http://pylxd.test/1.0/containers$',
+        })
+        config = {'name': 'an-new-container'}
+
+        self.assertRaises(
+            exceptions.CreateFailed,
+            container.Container.create, self.client, config)
+
     def test_reload(self):
         """A reload updates the properties of a container."""
         an_container = container.Container(

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -1,3 +1,5 @@
+import json
+
 from pylxd import container, exceptions
 from pylxd.tests import testing
 
@@ -21,6 +23,18 @@ class TestContainer(testing.PyLXDTestCase):
 
     def test_get_not_found(self):
         """NameError is raised when the container doesn't exist."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        })
+
         name = 'an-missing-container'
 
         self.assertRaises(
@@ -40,6 +54,10 @@ class TestContainer(testing.PyLXDTestCase):
         """If the container creation fails, CreateFailed is raised."""
         def create_fail(request, context):
             context.status_code = 500
+            return json.dumps({
+                'type': 'error',
+                'error': 'An unknown error',
+                'error_code': 500})
         self.add_rule({
             'text': create_fail,
             'method': 'POST',
@@ -62,6 +80,18 @@ class TestContainer(testing.PyLXDTestCase):
 
     def test_reload_not_found(self):
         """NameError is raised on a 404 for updating container."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        })
+
         an_container = container.Container(
             name='an-missing-container', _client=self.client)
 

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -32,7 +32,7 @@ class TestContainer(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',  # NOQA
         })
 
         name = 'an-missing-container'
@@ -89,7 +89,7 @@ class TestContainer(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',  # NOQA
         })
 
         an_container = container.Container(

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -1,4 +1,4 @@
-from pylxd import container
+from pylxd import container, exceptions
 from pylxd.tests import testing
 
 
@@ -24,7 +24,8 @@ class TestContainer(testing.PyLXDTestCase):
         name = 'an-missing-container'
 
         self.assertRaises(
-            NameError, container.Container.get, self.client, name)
+            exceptions.NotFound,
+            container.Container.get, self.client, name)
 
     def test_create(self):
         """A new container is created."""

--- a/pylxd/tests/test_image.py
+++ b/pylxd/tests/test_image.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 
 from pylxd import exceptions, image
 from pylxd.tests import testing
@@ -18,6 +19,10 @@ class TestImage(testing.PyLXDTestCase):
         """NotFound is raised when the image isn't found."""
         def not_found(request, context):
             context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
         self.add_rule({
             'text': not_found,
             'method': 'GET',
@@ -48,6 +53,10 @@ class TestImage(testing.PyLXDTestCase):
         """If image creation fails, CreateFailed is raised."""
         def create_fail(request, context):
             context.status_code = 500
+            return json.dumps({
+                'type': 'error',
+                'error': 'An unknown error',
+                'error_code': 500})
         self.add_rule({
             'text': create_fail,
             'method': 'POST',

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -1,3 +1,5 @@
+import json
+
 from pylxd import exceptions, profile
 from pylxd.tests import testing
 
@@ -16,6 +18,10 @@ class TestProfile(testing.PyLXDTestCase):
         """NotFound is raised on unknown profiles."""
         def not_found(request, context):
             context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
         self.add_rule({
             'text': not_found,
             'method': 'GET',
@@ -44,6 +50,10 @@ class TestProfile(testing.PyLXDTestCase):
         """CreateFailed is raised when errors occur."""
         def error(request, context):
             context.status_code = 503
+            return json.dumps({
+                'type': 'error',
+                'error': 'An unknown error',
+                'error_code': 500})
         self.add_rule({
             'text': error,
             'method': 'POST',

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -1,9 +1,30 @@
-from pylxd import profile
+from pylxd import exceptions, profile
 from pylxd.tests import testing
 
 
 class TestProfile(testing.PyLXDTestCase):
     """Tests for pylxd.profile.Profile."""
+
+    def test_get(self):
+        """A profile is fetched."""
+        name = 'an-profile'
+        an_profile = profile.Profile.get(self.client, name)
+
+        self.assertEqual(name, an_profile.name)
+
+    def test_get_not_found(self):
+        """NotFound is raised on unknown profiles."""
+        def not_found(request, context):
+            context.status_code = 404
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/profiles/(?P<container_name>.*)$',
+        })
+
+        self.assertRaises(
+            exceptions.NotFound,
+            profile.Profile.get, self.client, 'an-profile')
 
     def test_all(self):
         """A list of all profiles is returned."""
@@ -18,3 +39,18 @@ class TestProfile(testing.PyLXDTestCase):
 
         self.assertIsInstance(an_profile, profile.Profile)
         self.assertEqual('an-new-profile', an_profile.name)
+
+    def test_create_failed(self):
+        """CreateFailed is raised when errors occur."""
+        def error(request, context):
+            context.status_code = 503
+        self.add_rule({
+            'text': error,
+            'method': 'POST',
+            'url': r'^http://pylxd.test/1.0/profiles$',
+        })
+
+        self.assertRaises(
+            exceptions.CreateFailed,
+            profile.Profile.create, self.client,
+            name='an-new-profile', config={})

--- a/pylxd/tests/testing.py
+++ b/pylxd/tests/testing.py
@@ -17,3 +17,7 @@ class PyLXDTestCase(unittest.TestCase):
 
     def tearDown(self):
         mock_services.stop_http_mock()
+
+    def add_rule(self, rule):
+        """Add a rule to the mock LXD service."""
+        mock_services.update_http_rules([rule])


### PR DESCRIPTION
We've always known that our error handling has needed work. The original API over-caught things, and the new API doesn't catch anything. The new api's inability to catch things results in some really random errors (like, when `wait=True`, not finding the `operation` key in the returned dict).

We will likely need some sort of assertion on _every_ request we make, that makes sure we have the proper return statuses. We'll also need to think about the extra information we include in these new exceptions (a core reason why I try and use built-ins when I can).