### PR TITLE
Allow specification of devices in a profile

### DIFF
--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -44,12 +44,14 @@ class Profile(mixin.Marshallable):
         return profiles
 
     @classmethod
-    def create(cls, client, name, config):
+    def create(cls, client, name, config=None, devices=None):
         """Create a profile."""
-        client.api.profiles.post(json={
-            'name': name,
-            'config': config
-            })
+        profile = {'name': name}
+        if config is not None:
+            profile['config'] = config
+        if devices is not None:
+            profile['devices'] = devices
+        client.api.profiles.post(json=profile)
 
         return cls.get(client, name)
 

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -14,7 +14,7 @@ class TestProfile(testing.PyLXDTestCase):
     def test_create(self):
         """A new profile is created."""
         an_profile = profile.Profile.create(
-            self.client, name='an-new-profile', config={})
+            self.client, name='an-new-profile', config={}, devices={})
 
         self.assertIsInstance(an_profile, profile.Profile)
         self.assertEqual('an-new-profile', an_profile.name)


### PR DESCRIPTION
Currently it not possible to specify devices when creating a
LXD profile. Make config and devices
optional when creating an LXD profile. This is required
so we can attach disks, network interfaces, etc.

Signed-off-by: Chuck Short <chuck.short@canonical.com>