### PR TITLE
Partial objects and updating

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -80,7 +80,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
 
-    def reload(self):
+    def fetch(self):
         """Reload the container information."""
         response = self._client.api.containers[self.name].get()
         if response.status_code == 404:
@@ -88,10 +88,16 @@ class Container(mixin.Waitable, mixin.Marshallable):
                 'Container named "{}" has gone away'.format(self.name))
         for key, value in six.iteritems(response.json()['metadata']):
             setattr(self, key, value)
+    # XXX: rockstar (28 Mar 2016) - This method was named improperly
+    # originally. It's being kept here for backwards compatibility.
+    reload = fetch
 
     def update(self, wait=False):
         """Update the container in lxd from local changes."""
-        marshalled = self.marshall()
+        try:
+            marshalled = self.marshall()
+        except AttributeError:
+            raise exceptions.ObjectIncomplete()
         # These two properties are explicitly not allowed.
         del marshalled['name']
         del marshalled['status']

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -27,3 +27,15 @@ class NotFound(_LXDAPIException):
 
 class CreateFailed(_LXDAPIException):
     """Generic create failure exception."""
+
+
+class ObjectIncomplete(Exception):
+    """An exception raised when an object isn't completely populated.
+
+    When an object is fetched via `all`, it isn't a complete object
+    just yet. It requires a call to `fetch` to populate the object before
+    it can be pushed back up to the server.
+    """
+
+    def __str__(self):
+        return 'Object incomplete. Please call `fetch` before updating.'

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -92,7 +92,7 @@ RULES = [
     # Images
     {
         'text': json.dumps({'metadata': [
-            'http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
+            'http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
         ]}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/images$',
@@ -105,7 +105,24 @@ RULES = [
     {
         'text': json.dumps({
             'metadata': {
+                'aliases': [
+                    {
+                        'name': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
+                        'fingerprint': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
+                    }
+                ],
+                'architecture': 'x86_64',
+                'cached': False,
+                'filename': 'a_image.tar.bz2',
                 'fingerprint': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
+                'properties': {},
+                'size': 1,
+                'auto_update': False,
+                'created_at': '1983-06-16T02:42:00Z',
+                'expires_at': '1983-06-16T02:42:00Z',
+                'last_used_at': '1983-06-16T02:42:00Z',
+                'uploaded_at': '1983-06-16T02:42:00Z',
+
             },
         }),
         'method': 'GET',

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -27,6 +27,9 @@ def profile_GET(request, context):
         return json.dumps({
             'metadata': {
                 'name': name,
+                'description': 'An description',
+                'config': {},
+                'devices': {},
             },
         })
     else:

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -115,6 +115,14 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertTrue(an_container.ephemeral)
 
+    def test_update_partial_objects(self):
+        """A partially fetched profile can't be pushed."""
+        an_container = self.client.containers.all()[0]
+
+        self.assertRaises(
+            exceptions.ObjectIncomplete,
+            an_container.update)
+
     def test_rename(self):
         an_container = container.Container(
             name='an-container', _client=self.client)

--- a/pylxd/tests/test_image.py
+++ b/pylxd/tests/test_image.py
@@ -66,3 +66,38 @@ class TestImage(testing.PyLXDTestCase):
         self.assertRaises(
             exceptions.CreateFailed,
             image.Image.create, self.client, b'')
+
+    def test_update_partial_objects(self):
+        """A partially fetched image can't be pushed."""
+        a_image = self.client.images.all()[0]
+
+        self.assertRaises(
+            exceptions.ObjectIncomplete,
+            a_image.update)
+
+    def test_fetch(self):
+        """A partial object is fetched and populated."""
+        a_image = self.client.images.all()[0]
+
+        a_image.fetch()
+
+        self.assertEqual(1, a_image.size)
+
+    def test_fetch_notfound(self):
+        """A bogus image fetch raises NotFound."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
+        })
+        fingerprint = hashlib.sha256(b'').hexdigest()
+
+        a_image = image.Image(fingerprint=fingerprint, _client=self.client)
+
+        self.assertRaises(exceptions.NotFound, a_image.fetch)

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -67,6 +67,34 @@ class TestProfile(testing.PyLXDTestCase):
 
     def test_partial_objects(self):
         """A partially fetched profile can't be pushed."""
-        profile = self.client.profiles.all()[0]
+        an_profile = self.client.profiles.all()[0]
 
-        profile.update()
+        self.assertRaises(
+            exceptions.ObjectIncomplete,
+            an_profile.update)
+
+    def test_fetch(self):
+        """A partially fetched profile is made complete."""
+        an_profile = self.client.profiles.all()[0]
+
+        an_profile.fetch()
+
+        self.assertEqual('An description', an_profile.description)
+
+    def test_fetch_notfound(self):
+        """NotFound is raised on bogus profile fetches."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/profiles/(?P<container_name>.*)$',
+        })
+
+        an_profile = profile.Profile(name='an-profile', _client=self.client)
+
+        self.assertRaises(exceptions.NotFound, an_profile.fetch)

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -64,3 +64,9 @@ class TestProfile(testing.PyLXDTestCase):
             exceptions.CreateFailed,
             profile.Profile.create, self.client,
             name='an-new-profile', config={})
+
+    def test_partial_objects(self):
+        """A partially fetched profile can't be pushed."""
+        profile = self.client.profiles.all()[0]
+
+        profile.update()


### PR DESCRIPTION
We currently have a bug where, if an object is fetched via `all`, it's not yet a complete object. We only have the single identifying property. It must first be populated before we can really interact with it. `Container` already had some support for this, but if one tried to call `update` on a partial object before fetching, it would result in a less than friendly `AttributeError` when trying to marshall the object. `Profile` and `Image` had to grow support for `fetch`, while `Container`'s api needed to be renamed (with the old name kept around for backwards compatibility.