### PR TITLE
Deprecation warning

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -15,6 +15,7 @@
 import six
 
 from pylxd import exceptions, mixin
+from pylxd.deprecation import deprecated
 from pylxd.operation import Operation
 
 
@@ -90,7 +91,9 @@ class Container(mixin.Waitable, mixin.Marshallable):
             setattr(self, key, value)
     # XXX: rockstar (28 Mar 2016) - This method was named improperly
     # originally. It's being kept here for backwards compatibility.
-    reload = fetch
+    reload = deprecated(
+        "Container.reload is deprecated. Please use Container.fetch")(
+        fetch)
 
     def update(self, wait=False):
         """Update the container in lxd from local changes."""

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -54,7 +54,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
         Containers returned from this method will only have the name
         set, as that is the only property returned from LXD. If more
-        information is needed, `Container.reload` is the method call
+        information is needed, `Container.fetch` is the method call
         that should be used.
         """
         response = client.api.containers.get()
@@ -137,7 +137,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             })
         if wait:
             self.wait_for_operation(response.json()['operation'])
-            self.reload()
+            self.fetch()
 
     def state(self):
         response = self._client.api.containers[self.name].state.get()

--- a/pylxd/deprecation.py
+++ b/pylxd/deprecation.py
@@ -1,0 +1,24 @@
+import warnings
+
+warnings.simplefilter('once', DeprecationWarning)
+
+
+class deprecated():
+    """A decorator for warning about deprecation warnings.
+
+    The decorator takes an optional message argument. This message can
+    be used to direct the user to a new API or specify when it will
+    be removed.
+    """
+
+    def __init__(self, message=None):
+        self.message = message
+
+    def __call__(self, f):
+        def wrapped(*args, **kwargs):
+            if self.message is None:
+                self.message = '{} is deprecated and will be removed soon.'.format(
+                    f.__name__)
+            warnings.warn(self.message, DeprecationWarning)
+            return f(*args, **kwargs)
+        return wrapped

--- a/pylxd/deprecation.py
+++ b/pylxd/deprecation.py
@@ -11,13 +11,15 @@ class deprecated():
     be removed.
     """
 
+    DEFAULT_MESSAGE = '{} is deprecated and will be removed soon.'
+
     def __init__(self, message=None):
         self.message = message
 
     def __call__(self, f):
         def wrapped(*args, **kwargs):
             if self.message is None:
-                self.message = '{} is deprecated and will be removed soon.'.format(
+                self.message = self.DEFAULT_MESSAGE.format(
                     f.__name__)
             warnings.warn(self.message, DeprecationWarning)
             return f(*args, **kwargs)

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -69,16 +69,16 @@ class TestContainer(testing.PyLXDTestCase):
             exceptions.CreateFailed,
             container.Container.create, self.client, config)
 
-    def test_reload(self):
-        """A reload updates the properties of a container."""
+    def test_fetch(self):
+        """A fetch updates the properties of a container."""
         an_container = container.Container(
             name='an-container', _client=self.client)
 
-        an_container.reload()
+        an_container.fetch()
 
         self.assertTrue(an_container.ephemeral)
 
-    def test_reload_not_found(self):
+    def test_fetch_not_found(self):
         """NameError is raised on a 404 for updating container."""
         def not_found(request, context):
             context.status_code = 404
@@ -95,7 +95,7 @@ class TestContainer(testing.PyLXDTestCase):
         an_container = container.Container(
             name='an-missing-container', _client=self.client)
 
-        self.assertRaises(NameError, an_container.reload)
+        self.assertRaises(NameError, an_container.fetch)
 
     def test_update(self):
         """A container is updated."""


### PR DESCRIPTION
With 2.0, we committed to maintaining backwards compatibility for some amount of API stability. This is becoming more and more important as we expand our userbase. This patch adds a `deprecated` decorator, which emits a `DeprecationWarning` on any decorated object.

It's then used on `Container.reload`, which was replaced prior to 2.0.1, but not officially deprecated. All calls to `reload` have been replaced with `fetch`.