### PR TITLE
Update the mock service to be more strict

### DIFF
--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -21,19 +21,21 @@ def profiles_POST(request, context):
     return json.dumps({'metadata': {}})
 
 
+def snapshot_DELETE(request, context):
+    context.status_code = 202
+    return json.dumps({'operation': 'operation-abc'})
+
+
 def profile_GET(request, context):
     name = request.path.split('/')[-1]
-    if name in ('an-profile', 'an-new-profile'):
-        return json.dumps({
-            'metadata': {
-                'name': name,
-                'description': 'An description',
-                'config': {},
-                'devices': {},
-            },
-        })
-    else:
-        context.status_code = 404
+    return json.dumps({
+        'metadata': {
+            'name': name,
+            'description': 'An description',
+            'config': {},
+            'devices': {},
+        },
+    })
 
 
 RULES = [
@@ -63,7 +65,7 @@ RULES = [
             'ephemeral': True,
         }}),
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
         'text': json.dumps({'metadata': {
@@ -71,19 +73,19 @@ RULES = [
             'status_code': 103,
         }}),
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)/state$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },
     {
         'text': json.dumps({'metadata': [
             '/1.0/containers/an_container/snapshots/an-snapshot',
         ]}),
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)/snapshots$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
     },
     {
         'text': json.dumps({'operation': 'operation-abc'}),
         'method': 'POST',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)/snapshots$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
     },
     {
         'text': json.dumps({'metadata': {
@@ -91,32 +93,32 @@ RULES = [
             'stateful': False,
         }}),
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container>.*)/snapshots/(?P<snapshot>.*)$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
     {
         'text': json.dumps({'operation': 'operation-abc'}),
         'method': 'POST',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container>.*)/snapshots/(?P<snapshot>.*)$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': snapshot_DELETE,
         'method': 'DELETE',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container>.*)/snapshots/(?P<snapshot>.*)$',  # NOQA
+        'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
     {
         'text': json.dumps({'operation': 'operation-abc'}),
         'method': 'POST',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
         'text': json.dumps({'operation': 'operation-abc'}),
         'method': 'PUT',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
         'text': container_DELETE,
         'method': 'DELETE',
-        'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
 
     # Images
@@ -175,13 +177,18 @@ RULES = [
     {
         'text': profile_GET,
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/profiles/(?P<container_name>.*)$',
+        'url': r'^http://pylxd.test/1.0/profiles/(an-profile|an-new-profile)$',
     },
 
     # Operations
     {
         'text': '{"metadata": {"id": "operation-abc"}}',
         'method': 'GET',
-        'url': r'^http://pylxd.test/1.0/operations/(?P<operation_id>.*)$',
+        'url': r'^http://pylxd.test/1.0/operations/operation-abc$',
+    },
+    {
+        'text': '{"metadata": {}',
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/operations/operation-abc/wait$',
     },
 ]

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -32,7 +32,7 @@ class TestContainer(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',  # NOQA
+            'url': r'^http://pylxd.test/1.0/containers/an-missing-container$',  # NOQA
         })
 
         name = 'an-missing-container'
@@ -89,7 +89,7 @@ class TestContainer(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/containers/(?P<container_name>.*)$',  # NOQA
+            'url': r'^http://pylxd.test/1.0/containers/an-missing-container$',  # NOQA
         })
 
         an_container = container.Container(
@@ -224,7 +224,7 @@ class TestSnapshot(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'DELETE',
-            'url': r'^http://pylxd.test/1.0/containers/(?P<container>.*)/snapshots/(?P<snapshot>.*)$',  # NOQA
+            'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
         })
 
         snapshot = container.Snapshot(

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -25,7 +25,7 @@ class TestProfile(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/profiles/(?P<container_name>.*)$',
+            'url': r'^http://pylxd.test/1.0/profiles/an-profile$',
         })
 
         self.assertRaises(
@@ -99,7 +99,7 @@ class TestProfile(testing.PyLXDTestCase):
         self.add_rule({
             'text': not_found,
             'method': 'GET',
-            'url': r'^http://pylxd.test/1.0/profiles/(?P<container_name>.*)$',
+            'url': r'^http://pylxd.test/1.0/profiles/an-profile$',
         })
 
         an_profile = profile.Profile(name='an-profile', _client=self.client)


### PR DESCRIPTION
I was writing some tests and discovered that, well, our mock service was allowing a little too much through. This should make it stricter by removing some wildcard regexes.