### PR TITLE
Files manager

### DIFF
--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -4,7 +4,9 @@ class ClientConnectionFailed(Exception):
 
 class ClientAuthenticationFailed(Exception):
     """The LXD client's certificates are not trusted."""
-    message = "LXD client certificates are not trusted."""
+
+    def __str__(self):
+        return "LXD client certificates are not trusted."""
 
 
 class _LXDAPIException(Exception):
@@ -18,7 +20,9 @@ class _LXDAPIException(Exception):
 
     def __init__(self, data):
         self.data = data
-        self.message = self.data.get('error')
+
+    def __str__(self):
+        return self.data.get('error')
 
 
 class NotFound(_LXDAPIException):

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -46,6 +46,7 @@ RULES = [
         'url': r'^http://pylxd.test/1.0$',
     },
 
+
     # Containers
     {
         'text': json.dumps({'metadata': [
@@ -76,6 +77,24 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },
     {
+        'text': json.dumps({'operation': 'operation-abc'}),
+        'method': 'POST',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
+    },
+    {
+        'text': json.dumps({'operation': 'operation-abc'}),
+        'method': 'PUT',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
+    },
+    {
+        'text': container_DELETE,
+        'method': 'DELETE',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
+    },
+
+
+    # Container Snapshots
+    {
         'text': json.dumps({'metadata': [
             '/1.0/containers/an_container/snapshots/an-snapshot',
         ]}),
@@ -105,21 +124,20 @@ RULES = [
         'method': 'DELETE',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
+
+
+    # Container files
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': 'This is a getted file',
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fgetted$',  # NOQA
+    },
+    {
         'method': 'POST',
-        'url': r'^http://pylxd.test/1.0/containers/an-container$',
+        'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fputted$',  # NOQA
     },
-    {
-        'text': json.dumps({'operation': 'operation-abc'}),
-        'method': 'PUT',
-        'url': r'^http://pylxd.test/1.0/containers/an-container$',
-    },
-    {
-        'text': container_DELETE,
-        'method': 'DELETE',
-        'url': r'^http://pylxd.test/1.0/containers/an-container$',
-    },
+
+
 
     # Images
     {

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -232,3 +232,39 @@ class TestSnapshot(testing.PyLXDTestCase):
             name='an-snapshot')
 
         self.assertRaises(RuntimeError, snapshot.delete)
+
+
+class TestFiles(testing.PyLXDTestCase):
+    """Tests for pylxd.container.Container.files."""
+
+    def setUp(self):
+        super(TestFiles, self).setUp()
+        self.container = container.Container.get(self.client, 'an-container')
+
+    def test_put(self):
+        """A file is put on the container."""
+        data = 'The quick brown fox'
+
+        self.container.files.put('/tmp/putted', data)
+
+        # TODO: Add an assertion here
+
+    def test_get(self):
+        """A file is retrieved from the container."""
+        data = self.container.files.get('/tmp/getted')
+
+        self.assertEqual(b'This is a getted file', data)
+
+    def test_get_not_found(self):
+        """NotFound is raised on bogus filenames."""
+        def not_found(request, context):
+            context.status_code = 500
+        rule = {
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fgetted$',  # NOQA
+        }
+        self.add_rule(rule)
+
+        self.assertRaises(
+            exceptions.NotFound, self.container.files.get, '/tmp/getted')


### PR DESCRIPTION
This branch adds a manager-esque `FilesManager` to handle files, with accompanying tests.

Please review #120 first (I merged that into this branch; writing these tests were how I realized how loose the mock service was)