### PR TITLE
Add coverage exclusions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,6 @@ source = pylxd
 omit =
     pylxd/tests/*
     pylxd/deprecated/*
+exclude_lines =
+    def __str__
+    pragma: no cover


### PR DESCRIPTION
I added a commit hook that removed some cache files, like the coverage cache, and suddenly, I found a bunch of coverage stuff I had been missing. This patch adds some exclusions, like ignoring `__str__` methods. Also, apparently if you specify `exclude_lines`, you have to add the default `pragma: no cover` to it.