### PR TITLE
Cache LXD host info

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -131,7 +131,7 @@ class Client(object):
             if auth != "trusted":
                 raise exceptions.ClientAuthenticationFailed()
 
-            self.host_info = response.json()['metadata']['environment']
+            self.host_info = response.json()['metadata']
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.InvalidURL):
             raise exceptions.ClientConnectionFailed()

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -130,6 +130,8 @@ class Client(object):
             auth = response.json()['metadata']['auth']
             if auth != "trusted":
                 raise exceptions.ClientAuthenticationFailed()
+
+            self.host_info = response.json()['metadata']['environment']
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.InvalidURL):
             raise exceptions.ClientConnectionFailed()

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -41,7 +41,8 @@ def profile_GET(request, context):
 RULES = [
     # General service endpoints
     {
-        'text': json.dumps({'metadata': {'auth': 'trusted'}}),
+        'text': json.dumps({'metadata': {'auth': 'trusted',
+                                         'environment': {}}}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0$',
     },

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -16,7 +16,10 @@ class TestClient(unittest.TestCase):
         self.get = self.patcher.start()
 
         response = mock.MagicMock(status_code=200)
-        response.json.return_value = {'metadata': {'auth': 'trusted'}}
+        response.json.return_value = {'metadata': {
+            'auth': 'trusted',
+            'environment': {'storage': 'zfs'},
+        }}
         self.get.return_value = response
 
     def tearDown(self):
@@ -67,10 +70,17 @@ class TestClient(unittest.TestCase):
     def test_authentication_failed(self):
         """If the authentication fails, an exception is raised."""
         response = mock.MagicMock(status_code=200)
-        response.json.return_value = {'metadata': {'auth': 'untrusted'}}
+        response.json.return_value = {'metadata': {'auth': 'untrusted',
+                                                   'environment': {}
+                                                   }}
         self.get.return_value = response
 
         self.assertRaises(exceptions.ClientAuthenticationFailed, client.Client)
+
+    def test_host_info(self):
+        """Perform a host query """
+        an_client = client.Client()
+        self.assertEqual('zfs', an_client.host_info['storage'])
 
 
 class TestAPINode(unittest.TestCase):

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -70,9 +70,7 @@ class TestClient(unittest.TestCase):
     def test_authentication_failed(self):
         """If the authentication fails, an exception is raised."""
         response = mock.MagicMock(status_code=200)
-        response.json.return_value = {'metadata': {'auth': 'untrusted',
-                                                   'environment': {}
-                                                   }}
+        response.json.return_value = {'metadata': {'auth': 'untrusted'}}
         self.get.return_value = response
 
         self.assertRaises(exceptions.ClientAuthenticationFailed, client.Client)
@@ -80,7 +78,7 @@ class TestClient(unittest.TestCase):
     def test_host_info(self):
         """Perform a host query """
         an_client = client.Client()
-        self.assertEqual('zfs', an_client.host_info['storage'])
+        self.assertEqual('zfs', an_client.host_info['environment']['storage'])
 
 
 class TestAPINode(unittest.TestCase):


### PR DESCRIPTION
Cache LXD host info so that it can be queried via the API.

Signed-off-by: Chuck Short <chuck.short@canonical.com>