### PR TITLE
Fix integration tests

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -11,11 +11,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from pylxd import exceptions
+
 from integration.testing import IntegrationTestCase
 
 
 class TestContainers(IntegrationTestCase):
-    """Tests for `Client.containers`"""
+    """Tests for `Client.containers`."""
 
     def test_get(self):
         """A container is fetched by name."""
@@ -38,6 +40,7 @@ class TestContainers(IntegrationTestCase):
 
     def test_create(self):
         """Creates and returns a new container."""
+        _, alias = self.create_image()
         config = {
             'name': 'an-container',
             'architecture': '2',
@@ -45,7 +48,7 @@ class TestContainers(IntegrationTestCase):
             'ephemeral': True,
             'config': {'limits.cpu': '2'},
             'source': {'type': 'image',
-                       'alias': 'busybox'},
+                       'alias': alias},
         }
         self.addCleanup(self.delete_container, config['name'])
 
@@ -89,7 +92,7 @@ class TestContainer(IntegrationTestCase):
         self.container.delete(wait=True)
 
         self.assertRaises(
-            NameError, self.client.containers.get, self.container.name)
+            exceptions.NotFound, self.client.containers.get, self.container.name)
 
     def test_start_stop(self):
         """The container is started and then stopped."""

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -92,7 +92,8 @@ class TestContainer(IntegrationTestCase):
         self.container.delete(wait=True)
 
         self.assertRaises(
-            exceptions.NotFound, self.client.containers.get, self.container.name)
+            exceptions.NotFound,
+            self.client.containers.get, self.container.name)
 
     def test_start_stop(self):
         """The container is started and then stopped."""

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -35,8 +35,7 @@ class TestContainers(IntegrationTestCase):
 
         containers = self.client.containers.all()
 
-        self.assertEqual(1, len(containers))
-        self.assertEqual(name, containers[0].name)
+        self.assertIn(name, [c.name for c in containers])
 
     def test_create(self):
         """Creates and returns a new container."""

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -74,4 +74,5 @@ class TestImage(IntegrationTestCase):
         self.image.delete(wait=True)
 
         self.assertRaises(
-            exceptions.NotFound, self.client.images.get, self.image.fingerprint)
+            exceptions.NotFound,
+            self.client.images.get, self.image.fingerprint)

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -11,6 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from pylxd import exceptions
+
 from integration.testing import create_busybox_image, IntegrationTestCase
 
 
@@ -69,7 +71,7 @@ class TestImage(IntegrationTestCase):
 
     def test_delete(self):
         """The image is deleted."""
-        self.image.delete()
+        self.image.delete(wait=True)
 
         self.assertRaises(
-            NameError, self.client.images.get, self.image.fingerprint)
+            exceptions.NotFound, self.client.images.get, self.image.fingerprint)

--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -13,6 +13,8 @@
 #    under the License.
 import unittest
 
+from pylxd import exceptions
+
 from integration.testing import IntegrationTestCase
 
 
@@ -40,7 +42,7 @@ class TestProfiles(IntegrationTestCase):
     def test_create(self):
         """A profile is created."""
         name = 'an-profile'
-        config = {'limits.memory': '4GB'}
+        config = {'limits.memory': '1GB'}
         profile = self.client.profiles.create(name, config)
         self.addCleanup(self.delete_profile, name)
 
@@ -84,4 +86,4 @@ class TestProfile(IntegrationTestCase):
         self.profile.delete()
 
         self.assertRaises(
-            NameError, self.client.profiles.get, self.profile.name)
+            exceptions.NotFound, self.client.profiles.get, self.profile.name)

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -11,8 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import uuid
 import unittest
+import uuid
 
 from pylxd.client import Client
 from integration.busybox import create_busybox_image
@@ -27,6 +27,7 @@ class IntegrationTestCase(unittest.TestCase):
         self.lxd = self.client.api
 
     def generate_object_name(self):
+        """Generate a random object name."""
         # Underscores are not allowed in container names.
         test = self.id().split('.')[-1].replace('_', '')
         rando = str(uuid.uuid1()).split('-')[-1]
@@ -34,6 +35,8 @@ class IntegrationTestCase(unittest.TestCase):
 
     def create_container(self):
         """Create a container in lxd."""
+        fingerprint, alias = self.create_image()
+
         name = self.generate_object_name()
         machine = {
             'name': name,
@@ -42,7 +45,7 @@ class IntegrationTestCase(unittest.TestCase):
             'ephemeral': False,
             'config': {'limits.cpu': '2'},
             'source': {'type': 'image',
-                       'alias': 'busybox'},
+                       'alias': alias},
         }
         result = self.lxd['containers'].post(json=machine)
         operation_uuid = result.json()['operation'].split('/')[-1]
@@ -92,6 +95,7 @@ class IntegrationTestCase(unittest.TestCase):
         self.lxd.images[fingerprint].delete()
 
     def create_profile(self):
+        """Create a profile."""
         name = self.generate_object_name()
         config = {'limits.memory': '1GB'}
         self.lxd.profiles.post(json={
@@ -101,6 +105,7 @@ class IntegrationTestCase(unittest.TestCase):
         return name
 
     def delete_profile(self, name):
+        """Delete a profile."""
         self.lxd.profiles[name].delete()
 
     def assertCommon(self, response):

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -226,7 +226,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
     def delete_snapshot(self, name, wait=False):  # pragma: no cover
         """Delete a snapshot."""
         snapshot = self.snapshots.get(name)
-        snapshot.delete()
+        snapshot.delete(wait=wait)
 
     @deprecated('Container.get_file is deprecated. Please use Container.files.get')  # NOQA
     def get_file(self, filepath):  # pragma: no cover

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -53,7 +53,7 @@ class Profile(mixin.Marshallable):
             profile['devices'] = devices
         response = client.api.profiles.post(json=profile)
 
-        if response.status_code is not 202:
+        if response.status_code is not 200:
             raise exceptions.CreateFailed(response.json())
 
         return cls.get(client, name)

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -17,7 +17,7 @@ def images_POST(request, context):
 
 
 def profiles_POST(request, context):
-    context.status_code = 202
+    context.status_code = 200
     return json.dumps({'metadata': {}})
 
 


### PR DESCRIPTION
This branch fixes the integration tests. There are a few things to address here:

  - The tests have no external dependencies, and require no outside setup.
  - The tests clean up after themselves (using `addCleanup`, with the exception of when something goes very wrong; this seems more a bug in `unittest` than our issue)
  - The integration tests take 20 seconds on my machine (addressing somewhat unfounded concerns about them taking "too long")
  - The integration tests uncovered two bugs: (1) The deprecated `Container.delete_snapshot` wasn't forwarding the `wait` parameter, and (2) `Profile.create` returns a 200, not a 202 (because it's a synchronous operation).

After this is merged, I'll connect with Stephane and get them connected to the lxd jenkins.