### PR TITLE
Better http assertions

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -132,7 +132,7 @@ class TestContainer(IntegrationTestCase):
     def test_put_get_file(self):
         """A file is written to the container and then read."""
         filepath = '/tmp/an_file'
-        data = 'abcdef'
+        data = b'abcdef'
 
         retval = self.container.put_file(filepath, data)
 

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -11,6 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import time
+
 from pylxd import exceptions
 
 from integration.testing import create_busybox_image, IntegrationTestCase
@@ -33,6 +35,9 @@ class TestImages(IntegrationTestCase):
         fingerprint, _ = self.create_image()
         self.addCleanup(self.delete_image, fingerprint)
 
+        # XXX: rockstar (02 Jun 2016) - This seems to have a failure
+        # of some sort. This is a hack.
+        time.sleep(5)
         images = self.client.images.all()
 
         self.assertIn(fingerprint, [image.fingerprint for image in images])
@@ -42,8 +47,9 @@ class TestImages(IntegrationTestCase):
         path, fingerprint = create_busybox_image()
         self.addCleanup(self.delete_image, fingerprint)
 
-        with open(path) as f:
-            image = self.client.images.create(f.read(), wait=True)
+        with open(path, 'rb') as f:
+            data = f.read()
+            image = self.client.images.create(data, wait=True)
 
         self.assertEqual(fingerprint, image.fingerprint)
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -13,9 +13,9 @@
 #    under the License.
 import os
 
-try:
+try:  # pragma: no cover
     from urllib.parse import quote
-except ImportError:
+except ImportError:  # pragma: no cover
     from urllib import quote
 
 import requests

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -27,8 +27,7 @@ requests_unixsocket.monkeypatch()
 
 
 class _APINode(object):
-    """An api node object.
-    """
+    """An api node object."""
 
     def __init__(self, api_endpoint, cert=None, verify=True):
         self._api_endpoint = api_endpoint
@@ -50,21 +49,64 @@ class _APINode(object):
             '{}/{}'.format(self._api_endpoint, item),
             cert=self.session.cert, verify=self.session.verify)
 
+    def _assert_response(self, response, allowed_status_codes=(200,)):
+        """Assert properties of the response.
+
+        LXD's API clearly defines specific responses. If the API
+        response is something unexpected (i.e. an error), then
+        we need to raise an exception and have the call points
+        handle the errors or just let the issue be raised to the
+        user.
+        """
+        if response.status_code not in allowed_status_codes:
+            raise exceptions.LXDAPIException(response)
+
+        try:
+            data = response.json()
+        except ValueError:
+            # Not a JSON response
+            return
+
+        if response.status_code == 200:
+            # Synchronous request
+            try:
+                if data['type'] != 'sync':
+                    raise exceptions.LXDAPIException(response)
+            except KeyError:
+                # Missing 'type' in response
+                raise exceptions.LXDAPIException(response)
+
+        if response.status_code == 202:
+            try:
+                if data['type'] != 'async':
+                    raise exceptions.LXDAPIException(response)
+            except KeyError:
+                # Missing 'type' in response
+                raise exceptions.LXDAPIException(response)
+
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        return self.session.get(self._api_endpoint, *args, **kwargs)
+        response = self.session.get(self._api_endpoint, *args, **kwargs)
+        self._assert_response(response)
+        return response
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
-        return self.session.post(self._api_endpoint, *args, **kwargs)
+        response = self.session.post(self._api_endpoint, *args, **kwargs)
+        self._assert_response(response, allowed_status_codes=(200, 202))
+        return response
 
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
-        return self.session.put(self._api_endpoint, *args, **kwargs)
+        response = self.session.put(self._api_endpoint, *args, **kwargs)
+        self._assert_response(response, allowed_status_codes=(200, 202))
+        return response
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
-        return self.session.delete(self._api_endpoint, *args, **kwargs)
+        response = self.session.delete(self._api_endpoint, *args, **kwargs)
+        self._assert_response(response, allowed_status_codes=(200, 202))
+        return response
 
 
 class Client(object):

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -264,7 +264,8 @@ class Snapshot(mixin.Waitable, mixin.Marshallable):
     @classmethod
     def get(cls, client, container, name):
         try:
-            response = client.api.containers[container.name].snapshots[name].get()
+            response = client.api.containers[
+                container.name].snapshots[name].get()
         except exceptions.LXDAPIException as e:
             if e.response.status_code == 404:
                 raise exceptions.NotFound()

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -318,7 +318,5 @@ class Snapshot(mixin.Waitable, mixin.Marshallable):
         response = self._client.api.containers[
             self._container.name].snapshots[self.name].delete()
 
-        if response.status_code != 202:
-            raise RuntimeError('Error deleting snapshot {}'.format(self.name))
         if wait:
             self.wait_for_operation(response.json()['operation'])

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -30,11 +30,14 @@ class Image(mixin.Waitable, mixin.Marshallable):
     @classmethod
     def get(cls, client, fingerprint):
         """Get an image."""
-        response = client.api.images[fingerprint].get()
+        try:
+            response = client.api.images[fingerprint].get()
+        except exceptions.LXDAPIException as e:
+            if e.response.status_code == 404:
+                raise exceptions.NotFound()
+            raise
 
-        if response.status_code == 404:
-            raise exceptions.NotFound(response.json())
-        image = Image(_client=client, **response.json()['metadata'])
+        image = cls(_client=client, **response.json()['metadata'])
         return image
 
     @classmethod
@@ -45,7 +48,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
         images = []
         for url in response.json()['metadata']:
             fingerprint = url.split('/')[-1]
-            images.append(Image(_client=client, fingerprint=fingerprint))
+            images.append(cls(_client=client, fingerprint=fingerprint))
         return images
 
     @classmethod
@@ -64,7 +67,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
 
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])
-        return cls.get(client, fingerprint)
+        return cls(_client=client, fingerprint=fingerprint)
 
     def __init__(self, **kwargs):
         super(Image, self).__init__()
@@ -89,10 +92,12 @@ class Image(mixin.Waitable, mixin.Marshallable):
 
     def fetch(self):
         """Fetch the object from LXD, populating attributes."""
-        response = self._client.api.images[self.fingerprint].get()
-
-        if response.status_code == 404:
-            raise exceptions.NotFound(response.json())
+        try:
+            response = self._client.api.images[self.fingerprint].get()
+        except exceptions.LXDAPIException as e:
+            if e.response.status_code == 404:
+                raise exceptions.NotFound()
+            raise
 
         for key, val in six.iteritems(response.json()['metadata']):
             setattr(self, key, val)

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -59,11 +59,11 @@ class Image(mixin.Waitable, mixin.Marshallable):
         headers = {}
         if public:
             headers['X-LXD-Public'] = '1'
-        response = client.api.images.post(
-            data=image_data, headers=headers)
-
-        if response.status_code != 202:
-            raise exceptions.CreateFailed(response.json())
+        try:
+            response = client.api.images.post(
+                data=image_data, headers=headers)
+        except exceptions.LXDAPIException as e:
+            raise exceptions.CreateFailed(e.response.json())
 
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -54,10 +54,10 @@ class Profile(mixin.Marshallable):
             profile['config'] = config
         if devices is not None:
             profile['devices'] = devices
-        response = client.api.profiles.post(json=profile)
-
-        if response.status_code is not 200:
-            raise exceptions.CreateFailed(response.json())
+        try:
+            client.api.profiles.post(json=profile)
+        except exceptions.LXDAPIException as e:
+            raise exceptions.CreateFailed(e.response.json())
 
         return cls.get(client, name)
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -22,11 +22,25 @@ def images_POST(request, context):
         'metadata': {}})
 
 
+def image_DELETE(request, context):
+    context.status_code = 202
+    return json.dumps({
+        'type': 'async',
+        'operation': 'operation-abc'})
+
+
 def profiles_POST(request, context):
     context.status_code = 200
     return json.dumps({
         'type': 'sync',
         'metadata': {}})
+
+
+def profile_DELETE(request, context):
+    context.status_code = 200
+    return json.dumps({
+        'type': 'sync',
+        'operation': 'operation-abc'})
 
 
 def snapshot_DELETE(request, context):
@@ -213,6 +227,12 @@ RULES = [
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
     },
+    {
+        'text': image_DELETE,
+        'method': 'DELETE',
+        'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
+    },
+
 
     # Profiles
     {
@@ -234,6 +254,17 @@ RULES = [
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/profiles/(an-profile|an-new-profile)$',
     },
+    {
+        'text': json.dumps({'type': 'sync'}),
+        'method': 'PUT',
+        'url': r'^http://pylxd.test/1.0/profiles/(an-profile|an-new-profile)$',
+    },
+    {
+        'text': profile_DELETE,
+        'method': 'DELETE',
+        'url': r'^http://pylxd.test/1.0/profiles/(an-profile|an-new-profile)$',
+    },
+
 
     # Operations
     {

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -3,32 +3,43 @@ import json
 
 def containers_POST(request, context):
     context.status_code = 202
-    return json.dumps({'operation': 'operation-abc'})
+    return json.dumps({
+        'type': 'async',
+        'operation': 'operation-abc'})
 
 
 def container_DELETE(request, context):
     context.status_code = 202
-    return json.dumps({'operation': 'operation-abc'})
+    return json.dumps({
+        'type': 'async',
+        'operation': 'operation-abc'})
 
 
 def images_POST(request, context):
     context.status_code = 202
-    return json.dumps({'metadata': {}})
+    return json.dumps({
+        'type': 'async',
+        'metadata': {}})
 
 
 def profiles_POST(request, context):
     context.status_code = 200
-    return json.dumps({'metadata': {}})
+    return json.dumps({
+        'type': 'sync',
+        'metadata': {}})
 
 
 def snapshot_DELETE(request, context):
     context.status_code = 202
-    return json.dumps({'operation': 'operation-abc'})
+    return json.dumps({
+        'type': 'async',
+        'operation': 'operation-abc'})
 
 
 def profile_GET(request, context):
     name = request.path.split('/')[-1]
     return json.dumps({
+        'type': 'sync',
         'metadata': {
             'name': name,
             'description': 'An description',
@@ -41,8 +52,10 @@ def profile_GET(request, context):
 RULES = [
     # General service endpoints
     {
-        'text': json.dumps({'metadata': {'auth': 'trusted',
-                                         'environment': {}}}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': {'auth': 'trusted',
+                         'environment': {}}}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0$',
     },
@@ -50,9 +63,11 @@ RULES = [
 
     # Containers
     {
-        'text': json.dumps({'metadata': [
-            'http://pylxd.test/1.0/containers/an-container',
-        ]}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': [
+                'http://pylxd.test/1.0/containers/an-container',
+            ]}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers$',
     },
@@ -62,28 +77,36 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/containers$',
     },
     {
-        'text': json.dumps({'metadata': {
-            'name': 'an-container',
-            'ephemeral': True,
-        }}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': {
+                'name': 'an-container',
+                'ephemeral': True,
+            }}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
-        'text': json.dumps({'metadata': {
-            'status': 'Running',
-            'status_code': 103,
-        }}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': {
+                'status': 'Running',
+                'status_code': 103,
+            }}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': json.dumps({
+            'type': 'sync',  # This should be async
+            'operation': 'operation-abc'}),
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': json.dumps({
+            'type': 'sync',  # This should be async
+            'operation': 'operation-abc'}),
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
@@ -96,27 +119,35 @@ RULES = [
 
     # Container Snapshots
     {
-        'text': json.dumps({'metadata': [
-            '/1.0/containers/an_container/snapshots/an-snapshot',
-        ]}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': [
+                '/1.0/containers/an_container/snapshots/an-snapshot',
+            ]}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
     },
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': json.dumps({
+            'type': 'sync',  # This should be async
+            'operation': 'operation-abc'}),
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
     },
     {
-        'text': json.dumps({'metadata': {
-            'name': 'an_container/an-snapshot',
-            'stateful': False,
-        }}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': {
+                'name': 'an_container/an-snapshot',
+                'stateful': False,
+            }}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
     {
-        'text': json.dumps({'operation': 'operation-abc'}),
+        'text': json.dumps({
+            'type': 'sync',  # This should be async
+            'operation': 'operation-abc'}),
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
@@ -142,9 +173,11 @@ RULES = [
 
     # Images
     {
-        'text': json.dumps({'metadata': [
-            'http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
-        ]}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': [
+                'http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',  # NOQA
+            ]}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/images$',
     },
@@ -155,6 +188,7 @@ RULES = [
     },
     {
         'text': json.dumps({
+            'type': 'sync',
             'metadata': {
                 'aliases': [
                     {
@@ -182,9 +216,11 @@ RULES = [
 
     # Profiles
     {
-        'text': json.dumps({'metadata': [
-            'http://pylxd.test/1.0/profiles/an-profile',
-        ]}),
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': [
+                'http://pylxd.test/1.0/profiles/an-profile',
+            ]}),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/profiles$',
     },
@@ -201,12 +237,17 @@ RULES = [
 
     # Operations
     {
-        'text': '{"metadata": {"id": "operation-abc"}}',
+        'text': json.dumps({
+            'type': 'sync',
+            'metadata': {'id': 'operation-abc'},
+            }),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/operations/operation-abc$',
     },
     {
-        'text': '{"metadata": {}',
+        'text': json.dumps({
+            'type': 'sync',
+            }),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/operations/operation-abc/wait$',
     },

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -179,10 +179,26 @@ class TestAPINode(unittest.TestCase):
             node.post)
 
     @mock.patch('pylxd.client.requests.Session')
-    def test_post_missing_type(self, Session):
+    def test_post_missing_type_200(self, Session):
         """A missing response type raises an exception."""
         response = mock.Mock(**{
             'status_code': 200,
+            'json.return_value': {},
+        })
+        session = mock.Mock(**{'post.return_value': response})
+        Session.return_value = session
+
+        node = client._APINode('http://test.com')
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            node.post)
+
+    @mock.patch('pylxd.client.requests.Session')
+    def test_post_missing_type_202(self, Session):
+        """A missing response type raises an exception."""
+        response = mock.Mock(**{
+            'status_code': 202,
             'json.return_value': {},
         })
         session = mock.Mock(**{'post.return_value': response})

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -117,7 +117,11 @@ class TestAPINode(unittest.TestCase):
     @mock.patch('pylxd.client.requests.Session')
     def test_get(self, Session):
         """Perform a session get."""
-        session = mock.Mock()
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {'type': 'sync'},
+        })
+        session = mock.Mock(**{'get.return_value': response})
         Session.return_value = session
 
         node = client._APINode('http://test.com')
@@ -129,7 +133,11 @@ class TestAPINode(unittest.TestCase):
     @mock.patch('pylxd.client.requests.Session')
     def test_post(self, Session):
         """Perform a session post."""
-        session = mock.Mock()
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {'type': 'sync'},
+        })
+        session = mock.Mock(**{'post.return_value': response})
         Session.return_value = session
 
         node = client._APINode('http://test.com')
@@ -141,7 +149,11 @@ class TestAPINode(unittest.TestCase):
     @mock.patch('pylxd.client.requests.Session')
     def test_put(self, Session):
         """Perform a session put."""
-        session = mock.Mock()
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {'type': 'sync'},
+        })
+        session = mock.Mock(**{'put.return_value': response})
         Session.return_value = session
 
         node = client._APINode('http://test.com')
@@ -153,7 +165,11 @@ class TestAPINode(unittest.TestCase):
     @mock.patch('pylxd.client.requests.Session')
     def test_delete(self, Session):
         """Perform a session delete."""
-        session = mock.Mock()
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {'type': 'sync'},
+        })
+        session = mock.Mock(**{'delete.return_value': response})
         Session.return_value = session
 
         node = client._APINode('http://test.com')

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -147,6 +147,54 @@ class TestAPINode(unittest.TestCase):
         session.post.assert_called_once_with('http://test.com')
 
     @mock.patch('pylxd.client.requests.Session')
+    def test_post_200_not_sync(self, Session):
+        """A status code of 200 with async request raises an exception."""
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {'type': 'async'},
+        })
+        session = mock.Mock(**{'post.return_value': response})
+        Session.return_value = session
+
+        node = client._APINode('http://test.com')
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            node.post)
+
+    @mock.patch('pylxd.client.requests.Session')
+    def test_post_202_sync(self, Session):
+        """A status code of 202 with sync request raises an exception."""
+        response = mock.Mock(**{
+            'status_code': 202,
+            'json.return_value': {'type': 'sync'},
+        })
+        session = mock.Mock(**{'post.return_value': response})
+        Session.return_value = session
+
+        node = client._APINode('http://test.com')
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            node.post)
+
+    @mock.patch('pylxd.client.requests.Session')
+    def test_post_missing_type(self, Session):
+        """A missing response type raises an exception."""
+        response = mock.Mock(**{
+            'status_code': 200,
+            'json.return_value': {},
+        })
+        session = mock.Mock(**{'post.return_value': response})
+        Session.return_value = session
+
+        node = client._APINode('http://test.com')
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            node.post)
+
+    @mock.patch('pylxd.client.requests.Session')
     def test_put(self, Session):
         """Perform a session put."""
         response = mock.Mock(**{

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -79,7 +79,7 @@ class TestContainer(testing.PyLXDTestCase):
         self.assertTrue(an_container.ephemeral)
 
     def test_fetch_not_found(self):
-        """NameError is raised on a 404 for updating container."""
+        """NotFound is raised on a 404 for updating container."""
         def not_found(request, context):
             context.status_code = 404
             return json.dumps({
@@ -95,7 +95,7 @@ class TestContainer(testing.PyLXDTestCase):
         an_container = container.Container(
             name='an-missing-container', _client=self.client)
 
-        self.assertRaises(NameError, an_container.fetch)
+        self.assertRaises(exceptions.NotFound, an_container.fetch)
 
     def test_update(self):
         """A container is updated."""
@@ -214,7 +214,7 @@ class TestSnapshot(testing.PyLXDTestCase):
         # TODO: add an assertion here
 
     def test_delete_failure(self):
-        """If the response indicates delete failure, raise RuntimeError."""
+        """If the response indicates delete failure, raise an exception."""
         def not_found(request, context):
             context.status_code = 404
             return json.dumps({
@@ -231,7 +231,7 @@ class TestSnapshot(testing.PyLXDTestCase):
             _client=self.client, _container=self.container,
             name='an-snapshot')
 
-        self.assertRaises(RuntimeError, snapshot.delete)
+        self.assertRaises(exceptions.LXDAPIException, snapshot.delete)
 
 
 class TestFiles(testing.PyLXDTestCase):

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -320,4 +320,5 @@ class TestFiles(testing.PyLXDTestCase):
         self.add_rule(rule)
 
         self.assertRaises(
-            exceptions.LXDAPIException, self.container.files.get, '/tmp/getted')
+            exceptions.LXDAPIException,
+            self.container.files.get, '/tmp/getted')


### PR DESCRIPTION
This is a first pass at unifying the error handling of pylxd. The LXD API response codification is pretty tight, and it's pretty easy to figure out when something isn't right. I think there are probably a few more patches that can happen to help organize this a bit, but this is a good start.

Most of the patch is updating the tests to act more like the LXD API.