### PR TITLE
Add more tests for container state

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -59,7 +59,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         '_client',
         'architecture', 'config', 'created_at', 'devices', 'ephemeral',
         'expanded_config', 'expanded_devices', 'name', 'profiles', 'status'
-        ]
+    ]
 
     @classmethod
     def get(cls, client, name):
@@ -164,7 +164,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'action': state,
             'timeout': timeout,
             'force': force
-            })
+        })
         if wait:
             self.wait_for_operation(response.json()['operation'])
             self.fetch()
@@ -253,7 +253,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'environment': environment,
             'wait-for-websocket': False,
             'interactive': False,
-            })
+        })
         operation_id = response.json()['operation']
         self.wait_for_operation(operation_id)
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -106,8 +106,39 @@ RULES = [
             'metadata': {
                 'status': 'Running',
                 'status_code': 103,
+                'disk': {
+                    'root': {
+                        'usage': 10,
+                    }
+                },
+                'memory': {
+                    'usage': 15,
+                    'usage_peak': 20,
+                    'swap_usage': 0,
+                    'swap_usage_peak': 5,
+                },
+                'network': {
+                    'l0': {
+                        'addresses': [
+                            {'family': 'inet',
+                             'address': '127.0.0.1',
+                             'netmask': '8',
+                             'scope': 'local'}
+                        ],
+                    }
+                },
+                'pid': 69,
+                'processes': 100,
             }}),
         'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
+    },
+    {
+        'status_code': 202,
+        'json': {
+            'type': 'async',
+            'operation': 'operation-abc'},
+        'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },
     {

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -194,6 +194,36 @@ class TestContainerState(testing.PyLXDTestCase):
         self.assertEqual('Running', state.status)
         self.assertEqual(103, state.status_code)
 
+    def test_start(self):
+        """A container is started."""
+        an_container = container.Container.get(self.client, 'an-container')
+
+        an_container.start(wait=True)
+
+    def test_stop(self):
+        """A container is stopped."""
+        an_container = container.Container.get(self.client, 'an-container')
+
+        an_container.stop()
+
+    def test_restart(self):
+        """A container is restarted."""
+        an_container = container.Container.get(self.client, 'an-container')
+
+        an_container.restart()
+
+    def test_freeze(self):
+        """A container is suspended."""
+        an_container = container.Container.get(self.client, 'an-container')
+
+        an_container.freeze()
+
+    def test_unfreeze(self):
+        """A container is resumed."""
+        an_container = container.Container.get(self.client, 'an-container')
+
+        an_container.unfreeze()
+
 
 class TestContainerSnapshots(testing.PyLXDTestCase):
     """Tests for pylxd.container.Container.snapshots."""


### PR DESCRIPTION
While exploring the container state issue (that ended up being a non-issue), I added a bunch of test coverage...kinda. I mean, it executes the code path, but makes no assertions, which makes me slightly uncomfortable, but after pouring through the mock_services docs, it seemed non-trivial to handle that, and probably needs some re-working beyond the scope of a small branch.