### PR TITLE
Execute interactive

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -147,4 +147,6 @@ class TestContainer(IntegrationTestCase):
         self.container.start(wait=True)
         self.addCleanup(self.container.stop, wait=True)
 
-        self.container.execute('ls /')
+        stdout, stderr = self.container.execute(['echo', 'test'])
+
+        self.assertEqual('test\n', stdout)

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -259,7 +259,8 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
         fds = response.json()['metadata']['metadata']['fds']
         operation_id = response.json()['operation'].split('/')[-1]
-        parsed = parse.urlparse(self._client.api.operations[operation_id].websocket._api_endpoint)
+        parsed = parse.urlparse(
+            self._client.api.operations[operation_id].websocket._api_endpoint)
 
         manager = WebSocketManager()
 

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -248,9 +248,6 @@ class Container(mixin.Waitable, mixin.Marshallable):
 
     def execute(self, commands, environment={}):
         """Execute a command on the container."""
-        # XXX: rockstar (15 Feb 2016) - This functionality is limited by
-        # design, for now. It needs to grow the ability to return web sockets
-        # and perform interactive functions.
         if isinstance(commands, six.string_types):
             raise TypeError("First argument must be a list.")
         response = self._client.api.containers[self.name]['exec'].post(json={

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -59,7 +59,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         '_client',
         'architecture', 'config', 'created_at', 'devices', 'ephemeral',
         'expanded_config', 'expanded_devices', 'name', 'profiles', 'status'
-        ]
+    ]
 
     @classmethod
     def get(cls, client, name):
@@ -164,7 +164,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'action': state,
             'timeout': timeout,
             'force': force
-            })
+        })
         if wait:
             self.wait_for_operation(response.json()['operation'])
             self.fetch()
@@ -253,7 +253,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'environment': environment,
             'wait-for-websocket': False,
             'interactive': False,
-            })
+        })
         operation_id = response.json()['operation']
         self.wait_for_operation(operation_id)
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -129,7 +129,23 @@ RULES = [
         'method': 'DELETE',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
-
+    {
+        'json': {
+            'type': 'sync',  # This should be async
+            'metadata': {
+                'metadata': {
+                    'fds': {
+                        '0': 'abc',
+                        '1': 'def',
+                        '2': 'ghi',
+                        'control': 'jkl',
+                    }
+                },
+            },
+            'operation': 'operation-abc'},
+        'method': 'POST',
+        'url': r'^http://pylxd.test/1.0/containers/an-container/exec$',  # NOQA
+    },
 
     # Container Snapshots
     {


### PR DESCRIPTION
This patch changes the semantics of `Container.execute` a bit. Now it can _only_ take a list as a command argument (this is required as a lxd implementation detail). It also returns the stdout and stderr as text from the command (i.e. it now blocks waiting for the command to be run). This required some...adventurous...websocket work. If anything doesn't seem clear, just let me know and I'll try and add some documentation.