### PR TITLE
Operation work

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -18,7 +18,9 @@ from pylxd.deprecation import deprecated
 from pylxd.operation import Operation
 
 
-class ContainerState():
+class ContainerState(object):
+    """A simple object for representing container state."""
+
     def __init__(self, **kwargs):
         for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
@@ -30,6 +32,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
     This class is not intended to be used directly, but rather to be used
     via `Client.containers.create`.
     """
+
     class FilesManager(object):
         """A pseudo-manager for namespacing file operations."""
 
@@ -141,7 +144,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             json=marshalled)
 
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
 
     def rename(self, name, wait=False):
         """Rename a container."""
@@ -149,7 +152,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             self.name].post(json={'name': name})
 
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
         self.name = name
 
     def delete(self, wait=False):
@@ -157,7 +160,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         response = self._client.api.containers[self.name].delete()
 
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
 
     def _set_state(self, state, timeout=30, force=True, wait=False):
         response = self._client.api.containers[self.name].state.put(json={
@@ -166,7 +169,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'force': force
         })
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
             self.fetch()
 
     def state(self):
@@ -254,8 +257,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
             'wait-for-websocket': False,
             'interactive': False,
         })
-        operation_id = response.json()['operation']
-        self.wait_for_operation(operation_id)
+        Operation.wait_for_operation(self._client, response.json()['operation'])
 
 
 class Snapshot(mixin.Waitable, mixin.Marshallable):
@@ -296,7 +298,7 @@ class Snapshot(mixin.Waitable, mixin.Marshallable):
 
         snapshot = cls(_client=client, _container=container, name=name)
         if wait:
-            snapshot.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(client, response.json()['operation'])
         return snapshot
 
     def __init__(self, **kwargs):
@@ -310,7 +312,7 @@ class Snapshot(mixin.Waitable, mixin.Marshallable):
             self._container.name].snapshots[self.name].post(
             json={'name': new_name})
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
         self.name = new_name
 
     def delete(self, wait=False):
@@ -319,4 +321,4 @@ class Snapshot(mixin.Waitable, mixin.Marshallable):
             self._container.name].snapshots[self.name].delete()
 
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -144,7 +144,8 @@ class Container(mixin.Marshallable):
             json=marshalled)
 
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
 
     def rename(self, name, wait=False):
         """Rename a container."""
@@ -152,7 +153,8 @@ class Container(mixin.Marshallable):
             self.name].post(json={'name': name})
 
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
         self.name = name
 
     def delete(self, wait=False):
@@ -160,7 +162,8 @@ class Container(mixin.Marshallable):
         response = self._client.api.containers[self.name].delete()
 
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
 
     def _set_state(self, state, timeout=30, force=True, wait=False):
         response = self._client.api.containers[self.name].state.put(json={
@@ -169,7 +172,8 @@ class Container(mixin.Marshallable):
             'force': force
         })
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
             self.fetch()
 
     def state(self):
@@ -257,7 +261,8 @@ class Container(mixin.Marshallable):
             'wait-for-websocket': False,
             'interactive': False,
         })
-        Operation.wait_for_operation(self._client, response.json()['operation'])
+        Operation.wait_for_operation(
+            self._client, response.json()['operation'])
 
 
 class Snapshot(mixin.Marshallable):
@@ -312,7 +317,8 @@ class Snapshot(mixin.Marshallable):
             self._container.name].snapshots[self.name].post(
             json={'name': new_name})
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
         self.name = new_name
 
     def delete(self, wait=False):
@@ -321,4 +327,5 @@ class Snapshot(mixin.Marshallable):
             self._container.name].snapshots[self.name].delete()
 
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -26,7 +26,7 @@ class ContainerState(object):
             setattr(self, key, value)
 
 
-class Container(mixin.Waitable, mixin.Marshallable):
+class Container(mixin.Marshallable):
     """An LXD Container.
 
     This class is not intended to be used directly, but rather to be used
@@ -260,7 +260,7 @@ class Container(mixin.Waitable, mixin.Marshallable):
         Operation.wait_for_operation(self._client, response.json()['operation'])
 
 
-class Snapshot(mixin.Waitable, mixin.Marshallable):
+class Snapshot(mixin.Marshallable):
     """A container snapshot."""
 
     @classmethod

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -12,13 +12,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import hashlib
+
 import six
 
 from pylxd import exceptions, mixin
 from pylxd.operation import Operation
 
 
-class Image(mixin.Waitable, mixin.Marshallable):
+class Image(mixin.Marshallable):
     """A LXD Image."""
 
     __slots__ = [

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -88,7 +88,7 @@ class Image(mixin.Waitable, mixin.Marshallable):
         response = self._client.api.images[self.fingerprint].delete()
 
         if wait:
-            self.wait_for_operation(response.json()['operation'])
+            Operation.wait_for_operation(self._client, response.json()['operation'])
 
     def fetch(self):
         """Fetch the object from LXD, populating attributes."""

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -89,7 +89,8 @@ class Image(mixin.Marshallable):
         response = self._client.api.images[self.fingerprint].delete()
 
         if wait:
-            Operation.wait_for_operation(self._client, response.json()['operation'])
+            Operation.wait_for_operation(
+                self._client, response.json()['operation'])
 
     def fetch(self):
         """Fetch the object from LXD, populating attributes."""

--- a/pylxd/mixin.py
+++ b/pylxd/mixin.py
@@ -11,16 +11,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from pylxd.operation import Operation
-
-
-class Waitable(object):
-
-    def wait_for_operation(self, operation_id):
-        operation = Operation.get(self._client, operation_id)
-        operation.wait()
-        return operation
-
 
 class Marshallable(object):
 

--- a/pylxd/mixin.py
+++ b/pylxd/mixin.py
@@ -16,9 +16,6 @@ from pylxd.operation import Operation
 
 class Waitable(object):
 
-    def get_operation(self, operation_id):
-        return Operation.get(self._client, operation_id)
-
     def wait_for_operation(self, operation_id):
         operation = Operation.get(self._client, operation_id)
         operation.wait()

--- a/pylxd/mixin.py
+++ b/pylxd/mixin.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+
 class Marshallable(object):
 
     def marshall(self):

--- a/pylxd/mixin.py
+++ b/pylxd/mixin.py
@@ -11,17 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from pylxd.operation import Operation
 
 
 class Waitable(object):
 
     def get_operation(self, operation_id):
-        if operation_id.startswith('/'):
-            operation_id = operation_id.split('/')[-1]
-        return self._client.operations.get(operation_id)
+        return Operation.get(self._client, operation_id)
 
     def wait_for_operation(self, operation_id):
-        operation = self.get_operation(operation_id)
+        operation = Operation.get(self._client, operation_id)
         operation.wait()
         return operation
 

--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -26,14 +26,15 @@ class Operation(object):
     @classmethod
     def wait_for_operation(cls, client, operation_id):
         """Get an operation and wait for it to complete."""
-        if operation_id.startswith('/'):
-            operation_id = operation_id.split('/')[-1]
         operation = cls.get(client, operation_id)
         operation.wait()
+        return operation
 
     @classmethod
     def get(cls, client, operation_id):
         """Get an operation."""
+        if operation_id.startswith('/'):
+            operation_id = operation_id.split('/')[-1]
         response = client.api.operations[operation_id].get()
         return cls(_client=client, **response.json()['metadata'])
 

--- a/pylxd/tests/test_operation.py
+++ b/pylxd/tests/test_operation.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 from pylxd import operation
 from pylxd.tests import testing
 

--- a/pylxd/tests/test_operation.py
+++ b/pylxd/tests/test_operation.py
@@ -1,0 +1,22 @@
+from pylxd import operation
+from pylxd.tests import testing
+
+
+class TestOperation(testing.PyLXDTestCase):
+    """Tests for pylxd.operation.Operation."""
+
+    def test_get(self):
+        """Return an operation."""
+        name = 'operation-abc'
+
+        an_operation = operation.Operation.get(self.client, name)
+
+        self.assertEqual(name, an_operation.id)
+
+    def test_get_full_path(self):
+        """Return an operation even if the full path is specified."""
+        name = '/1.0/operations/operation-abc'
+
+        an_operation = operation.Operation.get(self.client, name)
+
+        self.assertEqual('operation-abc', an_operation.id)


### PR DESCRIPTION
Simplify the `Operation` handling work.

In general, operational work is entirely an implementation detail that we want to hide from the user. However, I made these two changes because it just made it easier for me as a developer (and reduced some repeated code).