### PR TITLE
Integration cleanup

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -116,29 +116,29 @@ class TestContainer(IntegrationTestCase):
         # NOTE: rockstar (15 Feb 2016) - Once again, multiple things
         # asserted in the same test.
         name = 'an-snapshot'
-        self.container.snapshot(name, wait=True)
+        snapshot = self.container.snapshots.create(name, wait=True)
 
-        self.assertEqual([name], self.container.list_snapshots())
+        self.assertEqual([name], [s.name for s in self.container.snapshots.all()])
 
         new_name = 'an-other-snapshot'
-        self.container.rename_snapshot(name, new_name, wait=True)
+        snapshot.rename(new_name, wait=True)
 
-        self.assertEqual([new_name], self.container.list_snapshots())
+        self.assertEqual([new_name], [s.name for s in self.container.snapshots.all()])
 
-        self.container.delete_snapshot(new_name, wait=True)
+        snapshot.delete(wait=True)
 
-        self.assertEqual([], self.container.list_snapshots())
+        self.assertEqual([], self.container.snapshots.all())
 
     def test_put_get_file(self):
         """A file is written to the container and then read."""
         filepath = '/tmp/an_file'
         data = b'abcdef'
 
-        retval = self.container.put_file(filepath, data)
+        retval = self.container.files.put(filepath, data)
 
         self.assertTrue(retval)
 
-        contents = self.container.get_file(filepath)
+        contents = self.container.files.get(filepath)
 
         self.assertEqual(data, contents)
 

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -118,12 +118,14 @@ class TestContainer(IntegrationTestCase):
         name = 'an-snapshot'
         snapshot = self.container.snapshots.create(name, wait=True)
 
-        self.assertEqual([name], [s.name for s in self.container.snapshots.all()])
+        self.assertEqual(
+            [name], [s.name for s in self.container.snapshots.all()])
 
         new_name = 'an-other-snapshot'
         snapshot.rename(new_name, wait=True)
 
-        self.assertEqual([new_name], [s.name for s in self.container.snapshots.all()])
+        self.assertEqual(
+            [new_name], [s.name for s in self.container.snapshots.all()])
 
         snapshot.delete(wait=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr>=1.6
 python-dateutil>=2.4.2
 six>=1.9.0
-ws4py>=0.3.4
+ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,>=2.5.2
 requests-unixsocket>=0.1.5
 cryptography>=1.4


### PR DESCRIPTION
This branch does a two things:

  - It fixes the integration tests to not raise `DeprecationWarning`s by using the current APIs.
  - It prevents the upgrade to ws4py `0.3.5` which breaks unix sockets. I'm not sure whether we should chase this. The maintainer of ws4py doesn't seem interested in maintaining it