### PR TITLE
Fix the cert handling.

### DIFF
--- a/pylxd/certificate.py
+++ b/pylxd/certificate.py
@@ -51,9 +51,8 @@ class Certificate(object):
         """Create a new certificate."""
         cert = x509.load_pem_x509_certificate(cert_data, default_backend())
         base64_cert = cert.public_bytes(Encoding.PEM).decode('utf-8')
-        if base64_cert.startswith('-----BEGIN CERTIFICATE-----'):
-            base64_cert = '\n'.join(
-                base64_cert.split('\n')[1:-2])
+        # STRIP OUT CERT META "-----BEGIN CERTIFICATE-----"
+        base64_cert = '\n'.join(base64_cert.split('\n')[1:-2])
         data = {
             'type': 'client',
             'certificate': base64_cert,

--- a/pylxd/certificate.py
+++ b/pylxd/certificate.py
@@ -50,9 +50,13 @@ class Certificate(object):
     def create(cls, client, password, cert_data):
         """Create a new certificate."""
         cert = x509.load_pem_x509_certificate(cert_data, default_backend())
+        base64_cert = cert.public_bytes(Encoding.PEM).decode('utf-8')
+        if base64_cert.startswith('-----BEGIN CERTIFICATE-----'):
+            base64_cert = '\n'.join(
+                base64_cert.split('\n')[1:-2])
         data = {
             'type': 'client',
-            'certificate': cert.public_bytes(Encoding.PEM).decode('utf-8'),
+            'certificate': base64_cert,
             'password': password,
         }
         client.api.certificates.post(json=data)


### PR DESCRIPTION
I thought I had handled this properly, but I guess not. When trying with a new host, I needed to add this code back in. It basically strips out the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` lines of the cert.

I wonder if LXD should accept this standard PEM format rather than just blowing up.