### PR TITLE
Update all objects to the model API

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -74,14 +74,6 @@ class _APINode(object):
                 # Missing 'type' in response
                 raise exceptions.LXDAPIException(response)
 
-        if response.status_code == 202:
-            try:
-                if data['type'] != 'async':
-                    raise exceptions.LXDAPIException(response)
-            except KeyError:
-                # Missing 'type' in response
-                raise exceptions.LXDAPIException(response)
-
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
         response = self.session.get(self._api_endpoint, *args, **kwargs)

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -44,9 +44,9 @@ class Container(model.Model):
     ephemeral = model.Attribute()
     expanded_config = model.Attribute()
     expanded_devices = model.Attribute()
-    name = model.Attribute()
+    name = model.Attribute(readonly=True)
     profiles = model.Attribute()
-    status = model.Attribute()
+    status = model.Attribute(readonly=True)
 
     snapshots = model.Manager()
     files = model.Manager()
@@ -133,22 +133,6 @@ class Container(model.Model):
     reload = deprecated(
         "Container.reload is deprecated. Please use Container.sync")(
         model.Model.sync)
-
-    def update(self, wait=False):
-        """Update the container in lxd from local changes."""
-        try:
-            marshalled = self.marshall()
-        except AttributeError:
-            raise exceptions.ObjectIncomplete()
-        # These two properties are explicitly not allowed.
-        del marshalled['name']
-        del marshalled['status']
-
-        response = self.api.put(json=marshalled)
-
-        if wait:
-            Operation.wait_for_operation(
-                self.client, response.json()['operation'])
 
     def rename(self, name, wait=False):
         """Rename a container."""

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -48,8 +48,8 @@ class Container(model.Model):
     profiles = model.Attribute()
     status = model.Attribute(readonly=True)
 
-    status_code = model.Attribute()
-    stateful = model.Attribute()
+    status_code = model.Attribute(readonly=True)
+    stateful = model.Attribute(readonly=True)
 
     snapshots = model.Manager()
     files = model.Manager()

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -102,7 +102,7 @@ class Container(model.Model):
 
         Containers returned from this method will only have the name
         set, as that is the only property returned from LXD. If more
-        information is needed, `Container.fetch` is the method call
+        information is needed, `Container.sync` is the method call
         that should be used.
         """
         response = client.api.containers.get()
@@ -155,7 +155,7 @@ class Container(model.Model):
         if wait:
             Operation.wait_for_operation(
                 self.client, response.json()['operation'])
-            self.fetch()
+            self.sync()
 
     def state(self):
         response = self.api.state.get()

--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -48,6 +48,9 @@ class Container(model.Model):
     profiles = model.Attribute()
     status = model.Attribute(readonly=True)
 
+    status_code = model.Attribute()
+    stateful = model.Attribute()
+
     snapshots = model.Manager()
     files = model.Manager()
 

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -79,14 +79,6 @@ class Image(model.Model):
             Operation.wait_for_operation(client, response.json()['operation'])
         return cls(client, fingerprint=fingerprint)
 
-    def update(self):
-        """Update LXD based on changes to this image."""
-        try:
-            marshalled = self.marshall()
-        except AttributeError:
-            raise exceptions.ObjectIncomplete()
-        self.api.put(json=marshalled)
-
     def export(self):
         """Export the image."""
         try:

--- a/pylxd/image.py
+++ b/pylxd/image.py
@@ -13,20 +13,29 @@
 #    under the License.
 import hashlib
 
-import six
-
-from pylxd import exceptions, mixin
+from pylxd import exceptions, model
 from pylxd.operation import Operation
 
 
-class Image(mixin.Marshallable):
+class Image(model.Model):
     """A LXD Image."""
+    aliases = model.Attribute()
+    auto_update = model.Attribute()
+    architecture = model.Attribute()
+    cached = model.Attribute()
+    created_at = model.Attribute()
+    expires_at = model.Attribute()
+    filename = model.Attribute()
+    fingerprint = model.Attribute()
+    last_used_at = model.Attribute()
+    properties = model.Attribute()
+    public = model.Attribute()
+    size = model.Attribute()
+    uploaded_at = model.Attribute()
 
-    __slots__ = [
-        '_client',
-        'aliases', 'architecture', 'created_at', 'expires_at', 'filename',
-        'fingerprint', 'properties', 'public', 'size', 'uploaded_at'
-    ]
+    @property
+    def api(self):
+        return self.client.api.images[self.fingerprint]
 
     @classmethod
     def get(cls, client, fingerprint):
@@ -38,7 +47,7 @@ class Image(mixin.Marshallable):
                 raise exceptions.NotFound()
             raise
 
-        image = cls(_client=client, **response.json()['metadata'])
+        image = cls(client, **response.json()['metadata'])
         return image
 
     @classmethod
@@ -49,7 +58,7 @@ class Image(mixin.Marshallable):
         images = []
         for url in response.json()['metadata']:
             fingerprint = url.split('/')[-1]
-            images.append(cls(_client=client, fingerprint=fingerprint))
+            images.append(cls(client, fingerprint=fingerprint))
         return images
 
     @classmethod
@@ -68,12 +77,7 @@ class Image(mixin.Marshallable):
 
         if wait:
             Operation.wait_for_operation(client, response.json()['operation'])
-        return cls(_client=client, fingerprint=fingerprint)
-
-    def __init__(self, **kwargs):
-        super(Image, self).__init__()
-        for key, value in six.iteritems(kwargs):
-            setattr(self, key, value)
+        return cls(client, fingerprint=fingerprint)
 
     def update(self):
         """Update LXD based on changes to this image."""
@@ -81,33 +85,12 @@ class Image(mixin.Marshallable):
             marshalled = self.marshall()
         except AttributeError:
             raise exceptions.ObjectIncomplete()
-        self._client.api.images[self.fingerprint].put(
-            json=marshalled)
-
-    def delete(self, wait=False):
-        """Delete the image."""
-        response = self._client.api.images[self.fingerprint].delete()
-
-        if wait:
-            Operation.wait_for_operation(
-                self._client, response.json()['operation'])
-
-    def fetch(self):
-        """Fetch the object from LXD, populating attributes."""
-        try:
-            response = self._client.api.images[self.fingerprint].get()
-        except exceptions.LXDAPIException as e:
-            if e.response.status_code == 404:
-                raise exceptions.NotFound()
-            raise
-
-        for key, val in six.iteritems(response.json()['metadata']):
-            setattr(self, key, val)
+        self.api.put(json=marshalled)
 
     def export(self):
         """Export the image."""
         try:
-            response = self._client.api.images[self.fingerprint].export.get()
+            response = self.api.export.get()
         except exceptions.LXDAPIException as e:
             if e.response.status_code == 404:
                 raise exceptions.NotFound()

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -25,6 +25,14 @@ class Attribute(object):
         self.validator = validator
 
 
+class Manager(object):
+    """A manager declaration.
+
+    This class signals to the model that it will have a Manager
+    attribute.
+    """
+
+
 class ModelType(type):
     """A Model metaclass.
 
@@ -37,10 +45,14 @@ class ModelType(type):
             raise TypeError('__slots__ should not be specified.')
         attributes = {}
         for_removal = []
+        managers = []
 
         for key, val in attrs.items():
             if type(val) == Attribute:
                 attributes[key] = val
+                for_removal.append(key)
+            if type(val) == Manager:
+                managers.append(key)
                 for_removal.append(key)
         for key in for_removal:
             del attrs[key]
@@ -51,6 +63,8 @@ class ModelType(type):
         for base in bases:
             if '__slots__' in dir(base):
                 slots = slots + base.__slots__
+        if len(managers) > 0:
+            slots = slots + managers
         attrs['__slots__'] = slots
         attrs['__attributes__'] = attributes
 

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -13,6 +13,8 @@
 #    under the License.
 import six
 
+from pylxd.deprecation import deprecated
+
 
 class Attribute(object):
     """A metadata class for model attributes."""
@@ -115,6 +117,7 @@ class Model(object):
         response = self.api.get()
         for key, val in response.json()['metadata'].items():
             setattr(self, key, val)
+    fetch = deprecated("fetch is deprecated; please use sync")(sync)
 
     def save(self):
         """Save data to the server.
@@ -127,4 +130,4 @@ class Model(object):
 
     def delete(self):
         """Delete an object from the server."""
-        raise NotImplementedError('delete is not implemented')
+        self.api.delete()

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -158,7 +158,7 @@ class Model(object):
         marshalled = self.marshall()
         response = self.api.put(json=marshalled)
 
-        if wait:
+        if response.json()['type'] == 'async' and wait:
             Operation.wait_for_operation(
                 self.client, response.json()['operation'])
     update = deprecated('update is deprecated; please use save')(save)

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -33,6 +33,13 @@ class Manager(object):
     """
 
 
+class Parent(object):
+    """A parent declaration.
+
+    Child managers must keep a reference to their parent.
+    """
+
+
 class ModelType(type):
     """A Model metaclass.
 
@@ -51,7 +58,7 @@ class ModelType(type):
             if type(val) == Attribute:
                 attributes[key] = val
                 for_removal.append(key)
-            if type(val) == Manager:
+            if type(val) in (Manager, Parent):
                 managers.append(key)
                 for_removal.append(key)
         for key in for_removal:

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -155,11 +155,7 @@ class Model(object):
         It should be a no-op when the object is not dirty, to prevent needless
         I/O.
         """
-        try:
-            marshalled = self.marshall()
-        except AttributeError:
-            raise exceptions.ObjectIncomplete()
-
+        marshalled = self.marshall()
         response = self.api.put(json=marshalled)
 
         if wait:

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -15,6 +15,7 @@ import six
 
 from pylxd import exceptions
 from pylxd.deprecation import deprecated
+from pylxd.operation import Operation
 
 
 class Attribute(object):
@@ -134,9 +135,13 @@ class Model(object):
         """
         raise NotImplementedError('save is not implemented')
 
-    def delete(self):
+    def delete(self, wait=False):
         """Delete an object from the server."""
-        self.api.delete()
+        response = self.api.delete()
+
+        if response.json()['type'] == 'async' and wait:
+            Operation.wait_for_operation(
+                self.client, response.json()['operation'])
 
     def marshall(self):
         """Marshall the object in preparation for updating to the server."""

--- a/pylxd/network.py
+++ b/pylxd/network.py
@@ -42,3 +42,7 @@ class Network(model.Model):
     @property
     def api(self):
         return self.client.api.networks[self.name]
+
+    def delete(self):
+        """Delete an object from the server."""
+        raise NotImplementedError('delete is not implemented')

--- a/pylxd/network.py
+++ b/pylxd/network.py
@@ -43,6 +43,10 @@ class Network(model.Model):
     def api(self):
         return self.client.api.networks[self.name]
 
+    def save(self, wait=False):
+        """Save is not available for networks."""
+        raise NotImplementedError('save is not implemented')
+
     def delete(self):
-        """Delete an object from the server."""
+        """Delete is not available for networks."""
         raise NotImplementedError('delete is not implemented')

--- a/pylxd/operation.py
+++ b/pylxd/operation.py
@@ -11,7 +11,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
 import six
 
 

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -17,7 +17,7 @@ from pylxd import exceptions, model
 class Profile(model.Model):
     """A LXD profile."""
 
-    name = model.Attribute()
+    name = model.Attribute(readonly=True)
     description = model.Attribute()
     config = model.Attribute()
     devices = model.Attribute()
@@ -63,17 +63,6 @@ class Profile(model.Model):
     @property
     def api(self):
         return self.client.api.profiles[self.name]
-
-    def update(self):
-        """Update the profile in LXD based on local changes."""
-        try:
-            marshalled = self.marshall()
-        except AttributeError:
-            raise exceptions.ObjectIncomplete()
-        # The name property cannot be updated.
-        del marshalled['name']
-
-        self.api.put(json=marshalled)
 
     def rename(self, new):
         """Rename the profile."""

--- a/pylxd/profile.py
+++ b/pylxd/profile.py
@@ -11,17 +11,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import six
-from pylxd import exceptions, mixin
+from pylxd import exceptions, model
 
 
-class Profile(mixin.Marshallable):
+class Profile(model.Model):
     """A LXD profile."""
 
-    __slots__ = [
-        '_client',
-        'config', 'devices', 'name'
-        ]
+    name = model.Attribute()
+    description = model.Attribute()
+    config = model.Attribute()
+    devices = model.Attribute()
 
     @classmethod
     def get(cls, client, name):
@@ -33,7 +32,7 @@ class Profile(mixin.Marshallable):
                 raise exceptions.NotFound()
             raise
 
-        return cls(_client=client, **response.json()['metadata'])
+        return cls(client, **response.json()['metadata'])
 
     @classmethod
     def all(cls, client):
@@ -43,7 +42,7 @@ class Profile(mixin.Marshallable):
         profiles = []
         for url in response.json()['metadata']:
             name = url.split('/')[-1]
-            profiles.append(cls(_client=client, name=name))
+            profiles.append(cls(client, name=name))
         return profiles
 
     @classmethod
@@ -61,10 +60,9 @@ class Profile(mixin.Marshallable):
 
         return cls.get(client, name)
 
-    def __init__(self, **kwargs):
-        super(Profile, self).__init__()
-        for key, value in six.iteritems(kwargs):
-            setattr(self, key, value)
+    @property
+    def api(self):
+        return self.client.api.profiles[self.name]
 
     def update(self):
         """Update the profile in LXD based on local changes."""
@@ -75,25 +73,9 @@ class Profile(mixin.Marshallable):
         # The name property cannot be updated.
         del marshalled['name']
 
-        self._client.api.profiles[self.name].put(json=marshalled)
+        self.api.put(json=marshalled)
 
     def rename(self, new):
         """Rename the profile."""
         raise NotImplementedError(
             'LXD does not currently support renaming profiles')
-
-    def delete(self):
-        """Delete a profile."""
-        self._client.api.profiles[self.name].delete()
-
-    def fetch(self):
-        """Fetch the object from LXD, populating attributes."""
-        try:
-            response = self._client.api.profiles[self.name].get()
-        except exceptions.LXDAPIException as e:
-            if e.response.status_code == 404:
-                raise exceptions.NotFound()
-            raise
-
-        for key, val in six.iteritems(response.json()['metadata']):
-            setattr(self, key, val)

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -138,17 +138,50 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/containers$',
     },
     {
-        'text': json.dumps({
+        'json': {
             'type': 'sync',
             'metadata': {
                 'name': 'an-container',
+
+                'architecture': "x86_64",
+                'config': {
+                    'security.privileged': "true",
+                },
+                'created_at': "1983-06-16T00:00:00-00:00",
+                'devices': {
+                    'root': {
+                        'path': "/",
+                        'type': "disk"
+                    }
+                },
                 'ephemeral': True,
-            }}),
+                'expanded_config': {
+                    'security.privileged': "true",
+                },
+                'expanded_devices': {
+                    'eth0': {
+                        'name': "eth0",
+                        'nictype': "bridged",
+                        'parent': "lxdbr0",
+                        'type': "nic"
+                    },
+                    'root': {
+                        'path': "/",
+                        'type': "disk"
+                    }
+                },
+                'profiles': [
+                    "default"
+                ],
+                'stateful': False,
+                'status': "Running",
+                'status_code': 103
+            }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
-        'text': json.dumps({
+        'json': {
             'type': 'sync',
             'metadata': {
                 'status': 'Running',
@@ -176,7 +209,7 @@ RULES = [
                 },
                 'pid': 69,
                 'processes': 100,
-            }}),
+            }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -112,6 +112,10 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/certificates/an-certificate$',
     },
     {
+        'json': {
+            'type': 'sync',
+            'metadata': {},
+        },
         'status_code': 202,
         'method': 'DELETE',
         'url': r'^http://pylxd.test/1.0/certificates/an-certificate$',

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -223,15 +223,17 @@ RULES = [
     },
     {
         'text': json.dumps({
-            'type': 'sync',  # This should be async
+            'type': 'async',
             'operation': 'operation-abc'}),
+        'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
     {
         'text': json.dumps({
-            'type': 'sync',  # This should be async
+            'type': 'async',
             'operation': 'operation-abc'}),
+        'status_code': 202,
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
@@ -242,7 +244,7 @@ RULES = [
     },
     {
         'json': {
-            'type': 'sync',  # This should be async
+            'type': 'async',
             'metadata': {
                 'metadata': {
                     'fds': {
@@ -254,6 +256,7 @@ RULES = [
                 },
             },
             'operation': 'operation-abc'},
+        'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/exec$',  # NOQA
     },
@@ -270,8 +273,9 @@ RULES = [
     },
     {
         'text': json.dumps({
-            'type': 'sync',  # This should be async
+            'type': 'async',
             'operation': 'operation-abc'}),
+        'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
     },
@@ -287,8 +291,9 @@ RULES = [
     },
     {
         'text': json.dumps({
-            'type': 'sync',  # This should be async
+            'type': 'async',
             'operation': 'operation-abc'}),
+        'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
     },
@@ -356,7 +361,8 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
     },
     {
-        'text': json.dumps({'type': 'sync'}),  # should be async
+        'text': json.dumps({'type': 'async', 'operation': 'operation-abc'}),
+        'status_code': 202,
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
     },

--- a/pylxd/tests/test_certificate.py
+++ b/pylxd/tests/test_certificate.py
@@ -46,7 +46,7 @@ class TestCertificate(testing.PyLXDTestCase):
     def test_fetch(self):
         """A partial object is fully fetched."""
         an_certificate = certificate.Certificate(
-            _client=self.client, fingerprint='an-certificate')
+            self.client, fingerprint='an-certificate')
 
         an_certificate.fetch()
 
@@ -57,6 +57,6 @@ class TestCertificate(testing.PyLXDTestCase):
         # XXX: rockstar (08 Jun 2016) - This just executes a code path. An
         # assertion should be added.
         an_certificate = certificate.Certificate(
-            _client=self.client, fingerprint='an-certificate')
+            self.client, fingerprint='an-certificate')
 
         an_certificate.delete()

--- a/pylxd/tests/test_certificate.py
+++ b/pylxd/tests/test_certificate.py
@@ -48,7 +48,7 @@ class TestCertificate(testing.PyLXDTestCase):
         an_certificate = certificate.Certificate(
             self.client, fingerprint='an-certificate')
 
-        an_certificate.fetch()
+        an_certificate.sync()
 
         self.assertEqual('certificate-content', an_certificate.certificate)
 

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -275,42 +275,10 @@ class TestAPINode(unittest.TestCase):
             node.post)
 
     @mock.patch('pylxd.client.requests.Session')
-    def test_post_202_sync(self, Session):
-        """A status code of 202 with sync request raises an exception."""
-        response = mock.Mock(**{
-            'status_code': 202,
-            'json.return_value': {'type': 'sync'},
-        })
-        session = mock.Mock(**{'post.return_value': response})
-        Session.return_value = session
-
-        node = client._APINode('http://test.com')
-
-        self.assertRaises(
-            exceptions.LXDAPIException,
-            node.post)
-
-    @mock.patch('pylxd.client.requests.Session')
     def test_post_missing_type_200(self, Session):
         """A missing response type raises an exception."""
         response = mock.Mock(**{
             'status_code': 200,
-            'json.return_value': {},
-        })
-        session = mock.Mock(**{'post.return_value': response})
-        Session.return_value = session
-
-        node = client._APINode('http://test.com')
-
-        self.assertRaises(
-            exceptions.LXDAPIException,
-            node.post)
-
-    @mock.patch('pylxd.client.requests.Session')
-    def test_post_missing_type_202(self, Session):
-        """A missing response type raises an exception."""
-        response = mock.Mock(**{
-            'status_code': 202,
             'json.return_value': {},
         })
         session = mock.Mock(**{'post.return_value': response})

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -92,11 +92,11 @@ class TestContainer(testing.PyLXDTestCase):
             container.Container.create, self.client, config)
 
     def test_fetch(self):
-        """A fetch updates the properties of a container."""
+        """A sync updates the properties of a container."""
         an_container = container.Container(
             self.client, name='an-container')
 
-        an_container.fetch()
+        an_container.sync()
 
         self.assertTrue(an_container.ephemeral)
 
@@ -117,7 +117,7 @@ class TestContainer(testing.PyLXDTestCase):
         an_container = container.Container(
             self.client, name='an-missing-container')
 
-        self.assertRaises(exceptions.NotFound, an_container.fetch)
+        self.assertRaises(exceptions.NotFound, an_container.sync)
 
     def test_fetch_error(self):
         """LXDAPIException is raised on error."""
@@ -136,7 +136,7 @@ class TestContainer(testing.PyLXDTestCase):
         an_container = container.Container(
             self.client, name='an-missing-container')
 
-        self.assertRaises(exceptions.LXDAPIException, an_container.fetch)
+        self.assertRaises(exceptions.LXDAPIException, an_container.sync)
 
     def test_update(self):
         """A container is updated."""
@@ -152,7 +152,7 @@ class TestContainer(testing.PyLXDTestCase):
         an_container.profiles = 1
         an_container.status = 1
 
-        an_container.update(wait=True)
+        an_container.save(wait=True)
 
         self.assertTrue(an_container.ephemeral)
 

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -269,8 +269,8 @@ class TestContainerSnapshots(testing.PyLXDTestCase):
 
         self.assertEqual(1, len(snapshots))
         self.assertEqual('an-snapshot', snapshots[0].name)
-        self.assertEqual(self.client, snapshots[0]._client)
-        self.assertEqual(self.container, snapshots[0]._container)
+        self.assertEqual(self.client, snapshots[0].client)
+        self.assertEqual(self.container, snapshots[0].container)
 
     def test_create(self):
         """Create a snapshot."""
@@ -290,7 +290,7 @@ class TestSnapshot(testing.PyLXDTestCase):
     def test_rename(self):
         """A snapshot is renamed."""
         snapshot = container.Snapshot(
-            _client=self.client, _container=self.container,
+            self.client, container=self.container,
             name='an-snapshot')
 
         snapshot.rename('an-renamed-snapshot', wait=True)
@@ -300,7 +300,7 @@ class TestSnapshot(testing.PyLXDTestCase):
     def test_delete(self):
         """A snapshot is deleted."""
         snapshot = container.Snapshot(
-            _client=self.client, _container=self.container,
+            self.client, container=self.container,
             name='an-snapshot')
 
         snapshot.delete(wait=True)
@@ -322,7 +322,7 @@ class TestSnapshot(testing.PyLXDTestCase):
         })
 
         snapshot = container.Snapshot(
-            _client=self.client, _container=self.container,
+            self.client, container=self.container,
             name='an-snapshot')
 
         self.assertRaises(exceptions.LXDAPIException, snapshot.delete)

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -94,7 +94,7 @@ class TestContainer(testing.PyLXDTestCase):
     def test_fetch(self):
         """A fetch updates the properties of a container."""
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
 
         an_container.fetch()
 
@@ -115,7 +115,7 @@ class TestContainer(testing.PyLXDTestCase):
         })
 
         an_container = container.Container(
-            name='an-missing-container', _client=self.client)
+            self.client, name='an-missing-container')
 
         self.assertRaises(exceptions.NotFound, an_container.fetch)
 
@@ -134,14 +134,14 @@ class TestContainer(testing.PyLXDTestCase):
         })
 
         an_container = container.Container(
-            name='an-missing-container', _client=self.client)
+            self.client, name='an-missing-container')
 
         self.assertRaises(exceptions.LXDAPIException, an_container.fetch)
 
     def test_update(self):
         """A container is updated."""
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
         an_container.architecture = 1
         an_container.config = {}
         an_container.created_at = 1
@@ -166,7 +166,7 @@ class TestContainer(testing.PyLXDTestCase):
 
     def test_rename(self):
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
 
         an_container.rename('an-renamed-container', wait=True)
 
@@ -178,7 +178,7 @@ class TestContainer(testing.PyLXDTestCase):
         # a code path. There should be an assertion here, but
         # it's not clear how to assert that, just yet.
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
 
         an_container.delete(wait=True)
 
@@ -192,7 +192,7 @@ class TestContainer(testing.PyLXDTestCase):
         _CommandWebsocketClient.return_value = fake_websocket
 
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
 
         stdout, _ = an_container.execute(['echo', 'test'])
 
@@ -201,7 +201,7 @@ class TestContainer(testing.PyLXDTestCase):
     def test_execute_string(self):
         """A command passed as string raises a TypeError."""
         an_container = container.Container(
-            name='an-container', _client=self.client)
+            self.client, name='an-container')
 
         self.assertRaises(TypeError, an_container.execute, 'apt-get update')
 

--- a/pylxd/tests/test_container.py
+++ b/pylxd/tests/test_container.py
@@ -156,14 +156,6 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertTrue(an_container.ephemeral)
 
-    def test_update_partial_objects(self):
-        """A partially fetched profile can't be pushed."""
-        an_container = self.client.containers.all()[0]
-
-        self.assertRaises(
-            exceptions.ObjectIncomplete,
-            an_container.update)
-
     def test_rename(self):
         an_container = container.Container(
             self.client, name='an-container')

--- a/pylxd/tests/test_image.py
+++ b/pylxd/tests/test_image.py
@@ -94,14 +94,6 @@ class TestImage(testing.PyLXDTestCase):
 
         a_image.update()
 
-    def test_update_partial_objects(self):
-        """A partially fetched image can't be pushed."""
-        a_image = self.client.images.all()[0]
-
-        self.assertRaises(
-            exceptions.ObjectIncomplete,
-            a_image.update)
-
     def test_fetch(self):
         """A partial object is fetched and populated."""
         a_image = self.client.images.all()[0]
@@ -125,7 +117,7 @@ class TestImage(testing.PyLXDTestCase):
         })
         fingerprint = hashlib.sha256(b'').hexdigest()
 
-        a_image = image.Image(fingerprint=fingerprint, _client=self.client)
+        a_image = image.Image(self.client, fingerprint=fingerprint)
 
         self.assertRaises(exceptions.NotFound, a_image.fetch)
 
@@ -144,7 +136,7 @@ class TestImage(testing.PyLXDTestCase):
         })
         fingerprint = hashlib.sha256(b'').hexdigest()
 
-        a_image = image.Image(fingerprint=fingerprint, _client=self.client)
+        a_image = image.Image(self.client, fingerprint=fingerprint)
 
         self.assertRaises(exceptions.LXDAPIException, a_image.fetch)
 

--- a/pylxd/tests/test_image.py
+++ b/pylxd/tests/test_image.py
@@ -90,15 +90,15 @@ class TestImage(testing.PyLXDTestCase):
     def test_update(self):
         """An image is updated."""
         a_image = self.client.images.all()[0]
-        a_image.fetch()
+        a_image.sync()
 
-        a_image.update()
+        a_image.save()
 
     def test_fetch(self):
         """A partial object is fetched and populated."""
         a_image = self.client.images.all()[0]
 
-        a_image.fetch()
+        a_image.sync()
 
         self.assertEqual(1, a_image.size)
 
@@ -119,7 +119,7 @@ class TestImage(testing.PyLXDTestCase):
 
         a_image = image.Image(self.client, fingerprint=fingerprint)
 
-        self.assertRaises(exceptions.NotFound, a_image.fetch)
+        self.assertRaises(exceptions.NotFound, a_image.sync)
 
     def test_fetch_error(self):
         """A 500 error raises LXDAPIException."""
@@ -138,7 +138,7 @@ class TestImage(testing.PyLXDTestCase):
 
         a_image = image.Image(self.client, fingerprint=fingerprint)
 
-        self.assertRaises(exceptions.LXDAPIException, a_image.fetch)
+        self.assertRaises(exceptions.LXDAPIException, a_image.sync)
 
     def test_delete(self):
         """An image is deleted."""

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -101,14 +101,6 @@ class TestProfile(testing.PyLXDTestCase):
 
         self.assertEqual({}, an_profile.config)
 
-    def test_update_partial_objects(self):
-        """A partially fetched profile can't be pushed."""
-        an_profile = self.client.profiles.all()[0]
-
-        self.assertRaises(
-            exceptions.ObjectIncomplete,
-            an_profile.update)
-
     def test_fetch(self):
         """A partially fetched profile is made complete."""
         an_profile = self.client.profiles.all()[0]
@@ -131,7 +123,7 @@ class TestProfile(testing.PyLXDTestCase):
             'url': r'^http://pylxd.test/1.0/profiles/an-profile$',
         })
 
-        an_profile = profile.Profile(name='an-profile', _client=self.client)
+        an_profile = profile.Profile(self.client, name='an-profile')
 
         self.assertRaises(exceptions.NotFound, an_profile.fetch)
 
@@ -149,7 +141,7 @@ class TestProfile(testing.PyLXDTestCase):
             'url': r'^http://pylxd.test/1.0/profiles/an-profile$',
         })
 
-        an_profile = profile.Profile(name='an-profile', _client=self.client)
+        an_profile = profile.Profile(self.client, name='an-profile')
 
         self.assertRaises(exceptions.LXDAPIException, an_profile.fetch)
 

--- a/pylxd/tests/test_profile.py
+++ b/pylxd/tests/test_profile.py
@@ -97,7 +97,7 @@ class TestProfile(testing.PyLXDTestCase):
         # it's not clear how to assert that, just yet.
         an_profile = profile.Profile.get(self.client, 'an-profile')
 
-        an_profile.update()
+        an_profile.save()
 
         self.assertEqual({}, an_profile.config)
 
@@ -105,7 +105,7 @@ class TestProfile(testing.PyLXDTestCase):
         """A partially fetched profile is made complete."""
         an_profile = self.client.profiles.all()[0]
 
-        an_profile.fetch()
+        an_profile.sync()
 
         self.assertEqual('An description', an_profile.description)
 
@@ -125,7 +125,7 @@ class TestProfile(testing.PyLXDTestCase):
 
         an_profile = profile.Profile(self.client, name='an-profile')
 
-        self.assertRaises(exceptions.NotFound, an_profile.fetch)
+        self.assertRaises(exceptions.NotFound, an_profile.sync)
 
     def test_fetch_error(self):
         """LXDAPIException is raised on fetch error."""
@@ -143,7 +143,7 @@ class TestProfile(testing.PyLXDTestCase):
 
         an_profile = profile.Profile(self.client, name='an-profile')
 
-        self.assertRaises(exceptions.LXDAPIException, an_profile.fetch)
+        self.assertRaises(exceptions.LXDAPIException, an_profile.sync)
 
     def test_delete(self):
         """A profile is deleted."""


### PR DESCRIPTION
`Container`, `Snapshot`, `Image`, `Profile`, and `Certificate` have all been updated to the stateful `Model` API that was merged this weekend.