### PR TITLE
Quote the path of unix endpoints.

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -13,6 +13,7 @@
 #    under the License.
 import json
 import os
+import os.path
 
 import requests
 import requests_unixsocket
@@ -163,7 +164,11 @@ class Client(object):
     def __init__(self, endpoint=None, version='1.0', cert=None, verify=True):
         self.cert = cert
         if endpoint is not None:
-            self.api = _APINode(endpoint, cert=cert, verify=verify)
+            if endpoint.startswith('/') and os.path.isfile(endpoint):
+                self.api = _APINode('http+unix://{}'.format(
+                    parse.quote(endpoint, safe='')))
+            else:
+                self.api = _APINode(endpoint, cert=cert, verify=verify)
         else:
             if 'LXD_DIR' in os.environ:
                 path = os.path.join(

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -13,6 +13,7 @@
 #    under the License.
 import json
 import os
+import os.path
 import unittest
 
 import mock
@@ -69,6 +70,18 @@ class TestClient(unittest.TestCase):
         expected = 'http://lxd/1.0'
 
         an_client = client.Client(endpoint=endpoint)
+
+        self.assertEqual(expected, an_client.api._api_endpoint)
+
+    def test_create_endpoint_unixsocket(self):
+        """Test with unix socket endpoint."""
+        endpoint = '/tmp/unix.socket'
+        expected = 'http+unix://%2Ftmp%2Funix.socket/1.0'
+
+        real_isfile = os.path.isfile
+        os.path.isfile = lambda x: True
+        an_client = client.Client(endpoint)
+        os.path.isfile = real_isfile
 
         self.assertEqual(expected, an_client.api._api_endpoint)
 


### PR DESCRIPTION
Allow to specify an existing socket as endpoint and quote it for requests.unixsocket.

Signed-off-by: Rene Jochum <rene@jochums.at>