### PR TITLE
Add dict method which includes readonly attributes to the model.

### DIFF
--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -182,3 +182,11 @@ class Model(object):
             if not val.readonly:
                 marshalled[key] = getattr(self, key)
         return marshalled
+
+    def dict(self):
+        """ Same as marshall but includes readonly attributes."""
+        marshalled = {}
+        for key, val in self.__attributes__.items():
+            if hasattr(self, key):
+                marshalled[key] = getattr(self, key)
+        return marshalled

--- a/pylxd/tests/test_model.py
+++ b/pylxd/tests/test_model.py
@@ -159,6 +159,17 @@ class TestModel(testing.PyLXDTestCase):
 
         self.assertEqual({'age': 15, 'data': {'key': 'val'}}, result)
 
+    def test_dict(self):
+        """ The object marshalled as dict with readonly attributes."""
+        item = Item(self.client, name='an-item', age=15, data={'key': 'val'})
+
+        result = item.dict()
+
+        self.assertEqual(
+            {'name': 'an-item', 'age': 15, 'data': {'key': 'val'}},
+            result
+        )
+
     def test_delete(self):
         """The object is deleted, and client is unset."""
         item = Item(self.client, name='an-item', age=15, data={'key': 'val'})


### PR DESCRIPTION
[See](https://github.com/pcdummy/saltstack-lxd-formula/commit/eed61b2617841fbf10400b3d499ef7145e25dffe) it in action

Signed-off-by: Rene Jochum <rene@jochums.at>