### PR TITLE
Fix traceback when using when LXD 2.1

### DIFF
--- a/pylxd/container.py
+++ b/pylxd/container.py
@@ -48,6 +48,7 @@ class Container(model.Model):
     name = model.Attribute(readonly=True)
     profiles = model.Attribute()
     status = model.Attribute(readonly=True)
+    last_used_at = model.Attribute(readonly=True)
 
     status_code = model.Attribute(readonly=True)
     stateful = model.Attribute(readonly=True)

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -184,6 +184,7 @@ RULES = [
                     'security.privileged': "true",
                 },
                 'created_at': "1983-06-16T00:00:00-00:00",
+                'last_used_at': "1983-06-16T00:00:00-00:00",
                 'devices': {
                     'root': {
                         'path': "/",


### PR DESCRIPTION
Fix traceback when using pylxd with 2.1:

File "/opt/stack/pylxd/pylxd/model.py", line 105, in __init__
  setattr(self, key, val)
File "/opt/stack/pylxd/pylxd/model.py", line 126, in __setattr__
  return super(Model, self).__setattr__(name, value)
AttributeError: 'Container' object has no attribute 'last_used_at'

Signed-off-by: Chuck Short <chuck.short@canonical.com>