### PR TITLE
Warn but don't raise exception on unknown attributes.

### DIFF
--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -11,6 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import warnings
+
 import six
 
 from pylxd.deprecation import deprecated
@@ -102,7 +104,14 @@ class Model(object):
         self.client = client
 
         for key, val in kwargs.items():
-            setattr(self, key, val)
+            try:
+                setattr(self, key, val)
+            except AttributeError:
+                warnings.warn(
+                    'Attempted to set unknown attribute "{}" '
+                    'on instance of "{}"'.format(
+                        key, self.__class__.__name__
+                    ))
         del self.__dirty__[:]
 
     def __getattribute__(self, name):

--- a/pylxd/tests/test_model.py
+++ b/pylxd/tests/test_model.py
@@ -69,10 +69,14 @@ class TestModel(testing.PyLXDTestCase):
         self.assertEqual('an-item', item.name)
 
     def test_init_unknown_attribute(self):
-        """Unknown attributes raise an exception."""
-        self.assertRaises(
-            AttributeError,
-            Item, self.client, name='an-item', nonexistent='SRSLY')
+        """Unknown attributes aren't set."""
+        item = Item(self.client, name='an-item', nonexistent='SRSLY')
+
+        try:
+            item.nonexistent
+            self.fail('item.nonexistent did not raise AttributeError')
+        except AttributeError:
+            pass
 
     def test_unknown_attribute(self):
         """Setting unknown attributes raise an exception."""


### PR DESCRIPTION
LXD adding new properties shouldn't cause current applications to fail,
but it is appropriate for pylxd to emit warnings about them.