### PR TITLE
Remove the deprecated apis in preparation for pylxd 2.1

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -68,10 +68,10 @@ class TestContainer(IntegrationTestCase):
         super(TestContainer, self).tearDown()
         self.delete_container(self.container.name)
 
-    def test_update(self):
+    def test_save(self):
         """The container is updated to a new config."""
         self.container.config['limits.cpu'] = '1'
-        self.container.update(wait=True)
+        self.container.save(wait=True)
 
         self.assertEqual('1', self.container.config['limits.cpu'])
         container = self.client.containers.get(self.container.name)

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -67,11 +67,11 @@ class TestImage(IntegrationTestCase):
         super(TestImage, self).tearDown()
         self.delete_image(self.image.fingerprint)
 
-    def test_update(self):
+    def test_save(self):
         """The image properties are updated."""
         description = 'an description'
         self.image.properties['description'] = description
-        self.image.update()
+        self.image.save()
 
         image = self.client.images.get(self.image.fingerprint)
         self.assertEqual(description, image.properties['description'])

--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -62,10 +62,10 @@ class TestProfile(IntegrationTestCase):
         super(TestProfile, self).tearDown()
         self.delete_profile(self.profile.name)
 
-    def test_update(self):
+    def test_save(self):
         """A profile is updated."""
         self.profile.config['limits.memory'] = '16GB'
-        self.profile.update()
+        self.profile.save()
 
         profile = self.client.profiles.get(self.profile.name)
         self.assertEqual('16GB', profile.config['limits.memory'])

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -15,7 +15,6 @@ import warnings
 
 import six
 
-from pylxd.deprecation import deprecated
 from pylxd.models.operation import Operation
 
 
@@ -155,7 +154,6 @@ class Model(object):
                 self.__dirty__.remove(key)
         if rollback:
             self.__dirty__.clear()
-    fetch = deprecated("fetch is deprecated; please use sync")(sync)
 
     def rollback(self):
         """Reset the object from the server."""
@@ -175,7 +173,6 @@ class Model(object):
             Operation.wait_for_operation(
                 self.client, response.json()['operation'])
         self.__dirty__.clear()
-    update = deprecated('update is deprecated; please use save')(save)
 
     def delete(self, wait=False):
         """Delete an object from the server."""

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -19,7 +19,6 @@ from ws4py.client import WebSocketBaseClient
 from ws4py.manager import WebSocketManager
 
 from pylxd import managers
-from pylxd.deprecation import deprecated
 from pylxd.models import _model as model
 from pylxd.models.operation import Operation
 
@@ -120,12 +119,6 @@ class Container(model.Model):
         self.snapshots = managers.SnapshotManager(self.client, self)
         self.files = self.FilesManager(self.client, self)
 
-    # XXX: rockstar (28 Mar 2016) - This method was named improperly
-    # originally. It's being kept here for backwards compatibility.
-    reload = deprecated(
-        "Container.reload is deprecated. Please use Container.sync")(
-        model.Model.sync)
-
     def rename(self, name, wait=False):
         """Rename a container."""
         response = self.api.post(json={'name': name})
@@ -187,38 +180,6 @@ class Container(model.Model):
                                timeout=timeout,
                                force=force,
                                wait=wait)
-
-    @deprecated('Container.snapshot is deprecated. Please use Container.snapshots.create')  # NOQA
-    def snapshot(self, name, stateful=False, wait=False):  # pragma: no cover
-        """Take a snapshot of the container."""
-        self.snapshots.create(name, stateful, wait)
-
-    @deprecated('Container.list_snapshots is deprecated. Please use Container.snapshots.all')  # NOQA
-    def list_snapshots(self):  # pragma: no cover
-        """List all container snapshots."""
-        return [s.name for s in self.snapshots.all()]
-
-    @deprecated('Container.rename_snapshot is deprecated. Please use Snapshot.rename')  # NOQA
-    def rename_snapshot(self, old, new, wait=False):  # pragma: no cover
-        """Rename a snapshot."""
-        snapshot = self.snapshots.get(old)
-        snapshot.rename(new, wait=wait)
-
-    @deprecated('Container.delete_snapshot is deprecated. Please use Snapshot.delete')  # NOQA
-    def delete_snapshot(self, name, wait=False):  # pragma: no cover
-        """Delete a snapshot."""
-        snapshot = self.snapshots.get(name)
-        snapshot.delete(wait=wait)
-
-    @deprecated('Container.get_file is deprecated. Please use Container.files.get')  # NOQA
-    def get_file(self, filepath):  # pragma: no cover
-        """Get a file from the container."""
-        return self.files.get(filepath)
-
-    @deprecated('Container.put_file is deprecated. Please use Container.files.put')  # NOQA
-    def put_file(self, filepath, data):  # pragma: no cover
-        """Put a file on the container."""
-        return self.files.put(filepath, data)
 
     def execute(self, commands, environment={}):
         """Execute a command on the container."""


### PR DESCRIPTION
(We're still leaving in `pylxd.deprecated`)