### PR TITLE
Add script to easily run the integration tests.

### DIFF
--- a/run_integration_tests
+++ b/run_integration_tests
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+CONTAINER_IMAGE=ubuntu:16.04
+CONTAINER_NAME=pylxd-`uuidgen | cut -d"-" -f1`
+
+# This creates a privileged container, because I was bumping into situations where it
+# seemed that we had maxed out user namespaces (I haven't checked it out, but it's likely
+# a bug in LXD).
+lxc launch $CONTAINER_IMAGE $CONTAINER_NAME -c security.nesting=true -c security.privileged=true
+sleep 5  # Wait for the network to come up
+lxc exec $CONTAINER_NAME -- apt-get install -y tox python3-dev libssl-dev libffi-dev build-essential
+
+lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
+# NOTE: rockstar (13 Sep 2016) - --recursive is not supported in lxd <2.1, so
+# until we have pervasive support for that, we'll do this tar hack.
+tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
+lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
+lxc delete --force $CONTAINER_NAME


### PR DESCRIPTION
The integration tests require a pretty clean environment, so running
them in my dev environment gets...weird sometimes. This will fire up
a container and run it inside that container. The caveat is that the
container is still (currently) privileged, so don't just run anyone's
integration tests on your machine. Look at them first.