### PR TITLE
Don't allow local connection clients to migrate

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -75,6 +75,14 @@ class _APINode(object):
                 # Missing 'type' in response
                 raise exceptions.LXDAPIException(response)
 
+    @property
+    def scheme(self):
+        return parse.urlparse(self.api._api_endpoint).scheme
+
+    @property
+    def netloc(self):
+        return parse.urlparse(self.api._api_endpoint).netloc
+
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
         response = self.session.get(self._api_endpoint, *args, **kwargs)
@@ -213,16 +221,15 @@ class Client(object):
 
     @property
     def websocket_url(self):
-        parsed = parse.urlparse(self.api._api_endpoint)
-        if parsed.scheme in ('http', 'https'):
-            host = parsed.netloc
-            if parsed.scheme == 'http':
+        if self.api.scheme in ('http', 'https'):
+            host = self.api.netloc
+            if self.api.scheme == 'http':
                 scheme = 'ws'
             else:
                 scheme = 'wss'
         else:
             scheme = 'ws+unix'
-            host = parse.unquote(parsed.netloc)
+            host = parse.unquote(self.api.netloc)
         url = parse.urlunparse((scheme, host, '', '', '', ''))
         return url
 

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -231,7 +231,7 @@ class Container(model.Model):
         first or criu must be installed on the source and destination
         machines.
         """
-        if self.api._api_endpoint.startswith('http+unix'):
+        if self.api.scheme in ('http+unix',):
             raise ValueError('Cannot migrate from a local client connection')
 
         self.sync()  # Make sure the object isn't stale

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -231,6 +231,9 @@ class Container(model.Model):
         first or criu must be installed on the source and destination
         machines.
         """
+        if self.api._api_endpoint.startswith('http+unix'):
+            raise ValueError('Cannot migrate from a local client connection')
+
         self.sync()  # Make sure the object isn't stale
         response = self.api.post(json={'migration': True})
         operation = self.client.operations.get(response.json()['operation'])

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -191,6 +191,23 @@ class TestContainer(testing.PyLXDTestCase):
         self.assertEqual('an-container', an_migrated_container.name)
         self.assertEqual(client2, an_migrated_container.client)
 
+    @mock.patch('pylxd.client._APINode.get')
+    def test_migrate_local_client(self, get):
+        """Migration from local clients is not supported."""
+        # Mock out the _APINode for the local instance.
+        response = mock.Mock()
+        response.json.return_value = {'metadata': {'fake': 'response'}}
+        response.status_code = 200
+        get.return_value = response
+
+        from pylxd.client import Client
+
+        client2 = Client(endpoint='http+unix://pylxd2.test')
+        an_container = models.Container(
+            client2, name='an-container')
+
+        self.assertRaises(ValueError, an_container.migrate, self.client)
+
     def test_publish(self):
         """Containers can be published."""
         self.add_rule({


### PR DESCRIPTION
If a connection to LXD is a local connection, it should not be used to migrate, because it won't have a routable connection.

Originally, I had the idea that we could iterate through all the addresses in `metadata.environment.addresses` until we found a valid one, and while that made me laugh at the stupidity and possible genius of the hack, I think it's better to explicitly put the burden on the user to have a routable connection.