### PR TITLE
Make ws4py an optional library.

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -18,7 +18,12 @@ import os.path
 import requests
 import requests_unixsocket
 from six.moves.urllib import parse
-from ws4py.client import WebSocketBaseClient
+try:
+    from ws4py.client import WebSocketBaseClient
+    _ws4py_installed = True
+except ImportError:  # pragma: no cover
+    WebSocketBaseClient = object
+    _ws4py_installed = False
 
 from pylxd import exceptions, managers
 
@@ -238,6 +243,9 @@ class Client(object):
         specified for implementation-specific handling
         of events as they occur.
         """
+        if not _ws4py_installed:
+            raise ValueError(
+                'This feature requires the optional ws4py library.')
         if websocket_client is None:
             websocket_client = _WebsocketClient
 

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -15,8 +15,13 @@ import time
 
 import six
 from six.moves.urllib import parse
-from ws4py.client import WebSocketBaseClient
-from ws4py.manager import WebSocketManager
+try:
+    from ws4py.client import WebSocketBaseClient
+    from ws4py.manager import WebSocketManager
+    _ws4py_installed = True
+except ImportError:  # pragma: no cover
+    WebSocketBaseClient = object
+    _ws4py_installed = False
 
 from pylxd import managers
 from pylxd.models import _model as model
@@ -183,6 +188,9 @@ class Container(model.Model):
 
     def execute(self, commands, environment={}):
         """Execute a command on the container."""
+        if not _ws4py_installed:
+            raise ValueError(
+                'This feature requires the optional ws4py library.')
         if isinstance(commands, six.string_types):
             raise TypeError("First argument must be a list.")
         response = self.api['exec'].post(json={

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -155,6 +155,7 @@ class TestContainer(testing.PyLXDTestCase):
 
         an_container.delete(wait=True)
 
+    @testing.requires_ws4py
     @mock.patch('pylxd.models.container._StdinWebsocket')
     @mock.patch('pylxd.models.container._CommandWebsocketClient')
     def test_execute(self, _CommandWebsocketClient, _StdinWebsocket):
@@ -171,6 +172,22 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertEqual('test\n', stdout)
 
+    def test_execute_no_ws4py(self):
+        """If ws4py is not installed, ValueError is raised."""
+        from pylxd.models import container
+        old_installed = container._ws4py_installed
+        container._ws4py_installed = False
+
+        def cleanup():
+            container._ws4py_installed = old_installed
+        self.addCleanup(cleanup)
+
+        an_container = models.Container(
+            self.client, name='an-container')
+
+        self.assertRaises(ValueError, an_container.execute, ['echo', 'test'])
+
+    @testing.requires_ws4py
     def test_execute_string(self):
         """A command passed as string raises a TypeError."""
         an_container = models.Container(

--- a/pylxd/tests/testing.py
+++ b/pylxd/tests/testing.py
@@ -6,6 +6,20 @@ from pylxd.client import Client
 from pylxd.tests import mock_lxd
 
 
+def requires_ws4py(f):
+    """Marks a test as requiring ws4py.
+
+    As ws4py is an optional dependency, some tests should
+    be skipped, as they won't run properly if ws4py is not
+    installed.
+    """
+    try:
+        import ws4py  # NOQA
+        return f
+    except ImportError:
+        return unittest.skip('ws4py is not installed')(f)
+
+
 class PyLXDTestCase(unittest.TestCase):
     """A test case for handling mocking of LXD services."""
 


### PR DESCRIPTION
Tests that require ws4py are skipped in environments that don't have
ws4py available.

Fixes #180