### PR TITLE
Image export

### DIFF
--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -53,8 +53,10 @@ the `LXD documentation`_.
 Image methods
 -------------
 
-  - `export` - Export the image. Returns binary data that is the
-    image itself.
+  - `export` - Export the image. Returns a file object with the contents
+    of the image. *Note: Prior to pylxd 2.1.1, this method returned a
+    bytestring with data; as it was not unbuffered, the API was severely
+    limited.*
 
   - `add_alias` - Add an alias to the image.
 

--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -152,3 +152,11 @@ class TestContainer(IntegrationTestCase):
         stdout, stderr = self.container.execute(['echo', 'test'])
 
         self.assertEqual('test\n', stdout)
+
+    def test_publish(self):
+        """A container is published."""
+        image = self.container.publish(wait=True)
+
+        self.assertIn(
+            image.fingerprint,
+            [i.fingerprint for i in self.client.images.all()])

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -85,8 +85,8 @@ class TestImage(IntegrationTestCase):
             self.client.images.get, self.image.fingerprint)
 
     def test_export(self):
-        """The imerage is successfully exported."""
-        data = self.image.export()
+        """The image is successfully exported."""
+        data = self.image.export().read()
         data_sha = hashlib.sha256(data).hexdigest()
 
         self.assertEqual(self.image.fingerprint, data_sha)

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -53,7 +53,8 @@ class _APINode(object):
             '{}/{}'.format(self._api_endpoint, item),
             cert=self.session.cert, verify=self.session.verify)
 
-    def _assert_response(self, response, allowed_status_codes=(200,)):
+    def _assert_response(
+            self, response, allowed_status_codes=(200,), stream=False):
         """Assert properties of the response.
 
         LXD's API clearly defines specific responses. If the API
@@ -64,6 +65,11 @@ class _APINode(object):
         """
         if response.status_code not in allowed_status_codes:
             raise exceptions.LXDAPIException(response)
+
+        # In the case of streaming, we can't validate the json the way we
+        # would with normal HTTP responses, so just ignore that entirely.
+        if stream:
+            return
 
         try:
             data = response.json()
@@ -90,12 +96,9 @@ class _APINode(object):
 
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        response = self.session.get(self._api_endpoint, *args, **kwargs)
-
-        # In the case of streaming, we can't validate the json the way we
-        # would with normal HTTP responses, so just ignore that entirely.
-        if not kwargs.get('stream', False):
-            self._assert_response(response)
+        response = self.session.get(
+            self._api_endpoint, *args, **kwargs)
+        self._assert_response(response, stream=kwargs.get('stream', False))
         return response
 
     def post(self, *args, **kwargs):

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -91,7 +91,11 @@ class _APINode(object):
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
         response = self.session.get(self._api_endpoint, *args, **kwargs)
-        self._assert_response(response)
+
+        # In the case of streaming, we can't validate the json the way we
+        # would with normal HTTP responses, so just ignore that entirely.
+        if not kwargs.get('stream', False):
+            self._assert_response(response)
         return response
 
     def post(self, *args, **kwargs):

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -448,7 +448,7 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
     },
     {
-        'text': '',
+        'text': '0' * 2048,
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/export$',  # NOQA
     },

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -143,7 +143,7 @@ class TestImage(testing.PyLXDTestCase):
         a_image = self.client.images.all()[0]
 
         data = a_image.export()
-        data_sha = hashlib.sha256(data).hexdigest()
+        data_sha = hashlib.sha256(data.read()).hexdigest()
 
         self.assertEqual(a_image.fingerprint, data_sha)
 

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -140,12 +140,13 @@ class TestImage(testing.PyLXDTestCase):
 
     def test_export(self):
         """An image is exported."""
+        expected = 'e2943f8d0b0e7d5835f9533722a6e25f669acb8980daee378b4edb44da212f51'  # NOQA
         a_image = self.client.images.all()[0]
 
         data = a_image.export()
         data_sha = hashlib.sha256(data.read()).hexdigest()
 
-        self.assertEqual(a_image.fingerprint, data_sha)
+        self.assertEqual(expected, data_sha)
 
     def test_export_not_found(self):
         """LXDAPIException is raised on export of bogus image."""

--- a/run_integration_tests
+++ b/run_integration_tests
@@ -8,6 +8,7 @@ CONTAINER_NAME=pylxd-`uuidgen | cut -d"-" -f1`
 # a bug in LXD).
 lxc launch $CONTAINER_IMAGE $CONTAINER_NAME -c security.nesting=true -c security.privileged=true
 sleep 5  # Wait for the network to come up
+lxc exec $CONTAINER_NAME -- apt-get update
 lxc exec $CONTAINER_NAME -- apt-get install -y tox python3-dev libssl-dev libffi-dev build-essential
 
 lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd


### PR DESCRIPTION
This branch adds the integration test for `Container.publish` and fixes the issue with `Image.export` storing the contents of the image in memory.

I updated the docs for `Image.export`, and fixed a small issue in `run_integration_tests` (which has become invaluable).

Sorry for the erroneous docstring changes. My editor does that automatically.