### PR TITLE
Improve documentation with a new container example

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -105,6 +105,10 @@ If you were to use an actual image source, you would be able to operate
 on the container, starting, stopping, snapshotting, and deleting the
 container.
 
+.. code-block:: python
+
+    >>> config = {'name': 'my-container', 'source': {'type': 'image', 'image': 'ubuntu/trusty'}}
+    >>> container = client.containers.create(config, wait=True)
     >>> container.start()
     >>> container.freeze()
     >>> container.delete()


### PR DESCRIPTION
I understand that the config specification for `create()` is beyond the
scope of the documentation, but I had to look directly in lxd's code to
figure how to create a container from a local image, something which, I
think, is a rather common usage of (py)lxd.

In this commit, I add an example of such config.

This additional example should be benefical to many other users.