### PR TITLE
Add missing attributes to Network model

### DIFF
--- a/pylxd/models/network.py
+++ b/pylxd/models/network.py
@@ -19,6 +19,8 @@ class Network(model.Model):
     name = model.Attribute()
     type = model.Attribute()
     used_by = model.Attribute()
+    config = model.Attribute()
+    managed = model.Attribute()
 
     @classmethod
     def get(cls, client, name):


### PR DESCRIPTION
Add "config" and "managed" attributes to the Network model. In addition
to be generally useful information, it also fixes warnings we were
getting upon calling `Client.networks.get()` about these attributes not
existing.