### PR TITLE
Fix the ws4py connection handling for container execution

### DIFF
--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -313,9 +313,6 @@ class _CommandWebsocketClient(WebSocketBaseClient):  # pragma: no cover
         else:
             self.buffer.append(message.data.decode('utf-8'))
 
-    def closed(self, code, reason=None):
-        print("Connection closed with code {} and reason {}".format(code, reason))
-
     @property
     def data(self):
         return ''.join(self.buffer)


### PR DESCRIPTION
This branch does a number of things. First, it simplifies _StdinWebsocket,
as we don't need most of what existed there. It closes immediately
after connection (and the command doesn't execute unless stdin is
also connected).

_CommandWebsocketClient learned how to pre-emptively close a connection.
We were previously waiting for the command to time out, which is why
the execute call was taking so long. This fixes #182.

The while loop that waits for the commands to complete had too long of
a delay, and had too much logic for whether the loop should continue
to wait. That while loop was also simplified.