### PR TITLE
Fully deprecate the old api

### DIFF
--- a/pylxd/__init__.py
+++ b/pylxd/__init__.py
@@ -16,5 +16,4 @@ import pbr.version
 
 __version__ = pbr.version.VersionInfo('pylxd').version_string()
 
-from pylxd.deprecated import api  # NOQA
 from pylxd.client import Client  # NOQA

--- a/pylxd/deprecated/tests/__init__.py
+++ b/pylxd/deprecated/tests/__init__.py
@@ -16,7 +16,7 @@ from ddt import data
 from ddt import unpack
 import unittest
 
-from pylxd import api
+from pylxd.deprecated import api
 
 
 class LXDAPITestBase(unittest.TestCase):


### PR DESCRIPTION
At this point, we should deprecate the code so far as to see that
anywhere it's being used has "pylxd.deprecated" in the import. I
think this makes sense for nova-lxd, but also for any code still
using the old API.