### PR TITLE
Require pyOpenSSL for older Python releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,>=2.5.2
 requests-unixsocket>=0.1.5
 cryptography>=1.4
+pyOpenSSL>=0.14;python_version<='2.7.8'


### PR DESCRIPTION
pyOpenSSL is a requirement for TLS 1.2 support in Python versions prior
to 2.7.9.