### PR TITLE
Add Container.execute_with_result

### DIFF
--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -583,7 +583,7 @@ RULES = [
     {
         'text': json.dumps({
             'type': 'sync',
-            'metadata': {'id': 'operation-abc'},
+            'metadata': {'id': 'operation-abc', 'metadata': {'return': 0}},
             }),
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/operations/operation-abc$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pbr>=1.6
 python-dateutil>=2.4.2
 six>=1.9.0
 ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
-requests!=2.8.0,>=2.5.2
+requests!=2.8.0,>=2.5.2,<2.12.0  # 2.12.0+ IDNA support causes breakages
 requests-unixsocket>=0.1.5
 cryptography>=1.4


### PR DESCRIPTION
Container.execute needs a sane, safe way to return more properties
than just stdout/stderr. Container.execute_with_result will return
a ContainerExecuteResult with the exit code, stdout and stdin, and
provides a mechanism for returning more properties in the future.

Container.execute now raises a DeprecationWarning as its return
value will change in 2.2