### PR TITLE
Authenticate fixes

### DIFF
--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import pylxd
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+from integration.testing import IntegrationTestCase
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+class TestClient(IntegrationTestCase):
+    """Tests for `Client`."""
+
+    def test_authenticate(self):
+        # This is another test with multiple assertions, as it is a test of
+        # flow, rather than a single source of functionality.
+        client = pylxd.Client('https://127.0.0.1:8443/', verify=False)
+
+        self.assertFalse(client.trusted)
+
+        client.authenticate('password')
+
+        self.assertTrue(client.trusted)

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -193,6 +193,7 @@ class Client(object):
                     parse.quote(endpoint, safe='')))
             else:
                 # Extra trailing slashes cause LXD to 301
+                endpoint = endpoint.rstrip('/')
                 if cert is None and (
                         os.path.exists(self.DEFAULT_CERTS[0]) and
                         os.path.exists(self.DEFAULT_CERTS[1])):

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -181,6 +181,10 @@ class Client(object):
 
     """
 
+    DEFAULT_CERTS = (
+        os.path.expanduser('~/.config/lxc/client.crt'),
+        os.path.expanduser('~/.config/lxc/client.key'))
+
     def __init__(self, endpoint=None, version='1.0', cert=None, verify=True):
         self.cert = cert
         if endpoint is not None:
@@ -188,6 +192,11 @@ class Client(object):
                 self.api = _APINode('http+unix://{}'.format(
                     parse.quote(endpoint, safe='')))
             else:
+                # Extra trailing slashes cause LXD to 301
+                if cert is None and (
+                        os.path.exists(self.DEFAULT_CERTS[0]) and
+                        os.path.exists(self.DEFAULT_CERTS[1])):
+                    cert = self.DEFAULT_CERTS
                 self.api = _APINode(endpoint, cert=cert, verify=verify)
         else:
             if 'LXD_DIR' in os.environ:
@@ -224,7 +233,7 @@ class Client(object):
     def authenticate(self, password):
         if self.trusted:
             return
-        cert = open(self.cert[0]).read().encode('utf-8')
+        cert = open(self.api.session.cert[0]).read().encode('utf-8')
         self.certificates.create(password, cert)
 
         # Refresh the host info

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -131,7 +131,7 @@ class TestClient(unittest.TestCase):
         certs = (
             os.path.join(os.path.dirname(__file__), 'lxd.crt'),
             os.path.join(os.path.dirname(__file__), 'lxd.key'))
-        an_client = client.Client(cert=certs)
+        an_client = client.Client('https://lxd', cert=certs)
 
         get_count = []
 

--- a/run_integration_tests
+++ b/run_integration_tests
@@ -11,9 +11,12 @@ sleep 5  # Wait for the network to come up
 lxc exec $CONTAINER_NAME -- apt-get update
 lxc exec $CONTAINER_NAME -- apt-get install -y tox python3-dev libssl-dev libffi-dev build-essential
 
+lxc exec $CONTAINER_NAME -- lxc config set core.trust_password password
+lxc exec $CONTAINER_NAME -- lxc config set core.https_address [::]
+
 lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
 # NOTE: rockstar (13 Sep 2016) - --recursive is not supported in lxd <2.1, so
 # until we have pervasive support for that, we'll do this tar hack.
 tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
 lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
-lxc delete --force $CONTAINER_NAME
+#lxc delete --force $CONTAINER_NAME

--- a/run_integration_tests
+++ b/run_integration_tests
@@ -19,4 +19,4 @@ lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
 # until we have pervasive support for that, we'll do this tar hack.
 tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
 lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
-#lxc delete --force $CONTAINER_NAME
+lxc delete --force $CONTAINER_NAME


### PR DESCRIPTION
A number of bugs all conspired to make sure authentication didn't work (and I'm not sure how it ever worked...) This branch fixes them all and adds an integration test to make sure it doesn't break again.

  - `pylxd.Client` had no `cert` attribute, which broke `authenticate`
  - If the endpoint url specified in `pylxd.Client` creation ended in a trailing slash, LXD was responding with 301 redirects (appropriately) which also broke authentication
  - The integration tests needed to be modified to support listening on the public http interface to test the authentication mechanism.