### PR TITLE
Allow multipart form uploads for images.

### DIFF
--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -97,7 +97,7 @@ class Image(model.Model):
         reliably determined consistently until after the image is indexed.
         """
 
-        if wait is False:
+        if wait is False:  # pragma: no cover
             warnings.warn(
                 'Image.create wait parameter ignored and will be removed in '
                 '2.3', DeprecationWarning)

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -71,7 +71,8 @@ class TestImage(testing.PyLXDTestCase):
     def test_create(self):
         """An image is created."""
         fingerprint = hashlib.sha256(b'').hexdigest()
-        a_image = models.Image.create(self.client, b'', public=True, wait=True)
+        a_image = models.Image.create(
+            self.client, b'', metadata=b'', public=True, wait=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -72,6 +72,15 @@ class TestImage(testing.PyLXDTestCase):
         """An image is created."""
         fingerprint = hashlib.sha256(b'').hexdigest()
         a_image = models.Image.create(
+            self.client, b'', public=True, wait=True)
+
+        self.assertIsInstance(a_image, models.Image)
+        self.assertEqual(fingerprint, a_image.fingerprint)
+
+    def test_create_with_metadata(self):
+        """An image with metadata is created."""
+        fingerprint = hashlib.sha256(b'').hexdigest()
+        a_image = models.Image.create(
             self.client, b'', metadata=b'', public=True, wait=True)
 
         self.assertIsInstance(a_image, models.Image)


### PR DESCRIPTION
In some cases, a user may want to upload a manifest with a raw image,
and pylxd previously didn't support that. This patch adds the needed
functionality.

As I did this, I found a bug in Image.create where fingerprint isn't
always reliably determined, so I have deprecated the ability to pass
a wait parameter to Image.create.

Fixes issue #172