### PR TITLE
Support more cryptography versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ six>=1.9.0
 ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,>=2.5.2,<2.12.0  # 2.12.0+ IDNA support causes breakages
 requests-unixsocket>=0.1.5
-cryptography>=1.4
+cryptography!=1.3.0,>=1.0
 pyOpenSSL>=0.14;python_version<='2.7.8'


### PR DESCRIPTION
A request came in to audit pylxd requirements to line up better
with Openstack. There isn't much overhead to maintaining it with
cryptography, as those developers are pretty responsible.