### PR TITLE
Add `NotFound` and `exists`

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -64,6 +64,8 @@ class _APINode(object):
         user.
         """
         if response.status_code not in allowed_status_codes:
+            if response.status_code == 404:
+                raise exceptions.NotFound(response)
             raise exceptions.LXDAPIException(response)
 
         # In the case of streaming, we can't validate the json the way we

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -26,5 +26,9 @@ class LXDAPIException(Exception):
         return self.response.content.decode('utf-8')
 
 
+class NotFound(LXDAPIException):
+    """An exception raised when an object is not found."""
+
+
 class ClientConnectionFailed(Exception):
     """An exception raised when the Client connection fails."""

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -15,6 +15,7 @@ import warnings
 
 import six
 
+from pylxd import exceptions
 from pylxd.models.operation import Operation
 
 
@@ -96,6 +97,7 @@ class Model(object):
     the instance is marked as dirty. `save` will save the changes
     to the server.
     """
+    NotFound = exceptions.NotFound
     __slots__ = ['client', '__dirty__']
 
     def __init__(self, client, **kwargs):

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -91,6 +91,15 @@ class Container(model.Model):
             return response.content
 
     @classmethod
+    def exists(cls, client, name):
+        """Determine whether a container exists."""
+        try:
+            client.containers.get(name)
+            return True
+        except cls.NotFound:
+            return False
+
+    @classmethod
     def get(cls, client, name):
         """Get a container by name."""
         response = client.api.containers[name].get()

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -58,6 +58,22 @@ class Image(model.Model):
         return self.client.api.images[self.fingerprint]
 
     @classmethod
+    def exists(cls, client, fingerprint, alias=False):
+        """Determine whether an image exists.
+
+        If `alias` is True, look up the image by its alias,
+        rather than its fingerprint.
+        """
+        try:
+            if alias:
+                client.images.get_by_alias(fingerprint)
+            else:
+                client.images.get(fingerprint)
+            return True
+        except cls.NotFound:
+            return False
+
+    @classmethod
     def get(cls, client, fingerprint):
         """Get an image."""
         response = client.api.images[fingerprint].get()

--- a/pylxd/models/profile.py
+++ b/pylxd/models/profile.py
@@ -23,6 +23,15 @@ class Profile(model.Model):
     devices = model.Attribute()
 
     @classmethod
+    def exists(cls, client, name):
+        """Determine whether a profile exists."""
+        try:
+            client.profiles.get(name)
+            return True
+        except cls.NotFound:
+            return False
+
+    @classmethod
     def get(cls, client, name):
         """Get a profile."""
         response = client.api.profiles[name].get()

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -72,6 +72,30 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertEqual(config['name'], an_new_container.name)
 
+    def test_exists(self):
+        """A container exists."""
+        name = 'an-container'
+
+        self.assertTrue(models.Container.exists(self.client, name))
+
+    def test_not_exists(self):
+        """A container exists."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/containers/an-missing-container$',  # NOQA
+        })
+
+        name = 'an-missing-container'
+
+        self.assertFalse(models.Container.exists(self.client, name))
+
     def test_fetch(self):
         """A sync updates the properties of a container."""
         an_container = models.Container(

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -62,6 +62,35 @@ class TestImage(testing.PyLXDTestCase):
 
         self.assertEqual(fingerprint, a_image.fingerprint)
 
+    def test_exists(self):
+        """An image is fetched."""
+        fingerprint = hashlib.sha256(b'').hexdigest()
+
+        self.assertTrue(models.Image.exists(self.client, fingerprint))
+
+    def test_exists_by_alias(self):
+        """An image is fetched."""
+        self.assertTrue(models.Image.exists(
+            self.client, 'an-alias', alias=True))
+
+    def test_not_exists(self):
+        """LXDAPIException is raised when the image isn't found."""
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
+        })
+
+        fingerprint = hashlib.sha256(b'').hexdigest()
+
+        self.assertFalse(models.Image.exists(self.client, fingerprint))
+
     def test_all(self):
         """A list of all images is returned."""
         images = models.Image.all(self.client)

--- a/pylxd/tests/models/test_profile.py
+++ b/pylxd/tests/models/test_profile.py
@@ -50,6 +50,28 @@ class TestProfile(testing.PyLXDTestCase):
             exceptions.LXDAPIException,
             models.Profile.get, self.client, 'an-profile')
 
+    def test_exists(self):
+        name = 'an-profile'
+
+        self.assertTrue(models.Profile.exists(self.client, name))
+
+    def test_not_exists(self):
+        def not_found(request, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/profiles/an-profile$',
+        })
+
+        name = 'an-profile'
+
+        self.assertFalse(models.Profile.exists(self.client, name))
+
     def test_all(self):
         """A list of all profiles is returned."""
         profiles = models.Profile.all(self.client)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2
+version = 2.2.1
 description-file =
     README.rst
 author = Paul Hummer


### PR DESCRIPTION
A common API issue that users report is an easier way to detect when an object just doesn't exist. This is becoming more and more apparent as I update methods in nova-lxd.

Add `NotFound` in the case of 404, which inherits from `LXDAPIException`, so it doesn't break backwards compatibility.

`Container`, `Image`, and `Profile` now have a `exists` class method, so that one can do `client.containers.exists('an-container')` as a wrapper around this new functionality.