### PR TITLE
Add websocket context manager

### DIFF
--- a/pylxd/managers.py
+++ b/pylxd/managers.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import functools
 import importlib
 import inspect
@@ -51,3 +53,11 @@ class ProfileManager(BaseManager):
 
 class SnapshotManager(BaseManager):
     manager_for = 'pylxd.models.Snapshot'
+
+
+@contextmanager
+def web_socket_manager(manager):
+    try:
+        yield manager
+    finally:
+        manager.stop()

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -200,7 +200,6 @@ class Container(model.Model):
                                force=force,
                                wait=wait)
 
-
     def execute(self, commands, environment={}):
         """Execute a command on the container.
 
@@ -228,10 +227,12 @@ class Container(model.Model):
             stdin = _StdinWebsocket(self.client.websocket_url)
             stdin.resource = '{}?secret={}'.format(parsed.path, fds['0'])
             stdin.connect()
-            stdout = _CommandWebsocketClient(manager, self.client.websocket_url)
+            stdout = _CommandWebsocketClient(
+                manager, self.client.websocket_url)
             stdout.resource = '{}?secret={}'.format(parsed.path, fds['1'])
             stdout.connect()
-            stderr = _CommandWebsocketClient(manager, self.client.websocket_url)
+            stderr = _CommandWebsocketClient(
+                manager, self.client.websocket_url)
             stderr.resource = '{}?secret={}'.format(parsed.path, fds['2'])
             stderr.connect()
 
@@ -244,7 +245,6 @@ class Container(model.Model):
 
             return _ContainerExecuteResult(
                 operation.metadata['return'], stdout.data, stderr.data)
-
 
     def migrate(self, new_client, wait=False):
         """Migrate a container.

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -200,6 +200,7 @@ class Container(model.Model):
                                force=force,
                                wait=wait)
 
+
     def execute(self, commands, environment={}):
         """Execute a command on the container.
 
@@ -223,26 +224,27 @@ class Container(model.Model):
         parsed = parse.urlparse(
             self.client.api.operations[operation_id].websocket._api_endpoint)
 
-        manager = WebSocketManager()
+        with managers.web_socket_manager(WebSocketManager()) as manager:
+            stdin = _StdinWebsocket(self.client.websocket_url)
+            stdin.resource = '{}?secret={}'.format(parsed.path, fds['0'])
+            stdin.connect()
+            stdout = _CommandWebsocketClient(manager, self.client.websocket_url)
+            stdout.resource = '{}?secret={}'.format(parsed.path, fds['1'])
+            stdout.connect()
+            stderr = _CommandWebsocketClient(manager, self.client.websocket_url)
+            stderr.resource = '{}?secret={}'.format(parsed.path, fds['2'])
+            stderr.connect()
 
-        stdin = _StdinWebsocket(self.client.websocket_url)
-        stdin.resource = '{}?secret={}'.format(parsed.path, fds['0'])
-        stdin.connect()
-        stdout = _CommandWebsocketClient(manager, self.client.websocket_url)
-        stdout.resource = '{}?secret={}'.format(parsed.path, fds['1'])
-        stdout.connect()
-        stderr = _CommandWebsocketClient(manager, self.client.websocket_url)
-        stderr.resource = '{}?secret={}'.format(parsed.path, fds['2'])
-        stderr.connect()
+            manager.start()
 
-        manager.start()
+            while len(manager.websockets.values()) > 0:
+                time.sleep(.1)
 
-        while len(manager.websockets.values()) > 0:
-            time.sleep(.1)
+            operation = self.client.operations.get(operation_id)
 
-        operation = self.client.operations.get(operation_id)
-        return _ContainerExecuteResult(
-            operation.metadata['return'], stdout.data, stderr.data)
+            return _ContainerExecuteResult(
+                operation.metadata['return'], stdout.data, stderr.data)
+
 
     def migrate(self, new_client, wait=False):
         """Migrate a container.


### PR DESCRIPTION
I've been receiving the too many open files issue pointed out in Issue #209 using lxd to run containers in a testing environment. 

This is a simple patch that prevents exhausting file descriptors after "too many" calls to execute. Not sure if this is the greatest approach but it's a simple fix.