### PR TITLE
Update containers.rst

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -107,7 +107,7 @@ container.
 
 .. code-block:: python
 
-    >>> config = {'name': 'my-container', 'source': {'type': 'image', 'image': 'ubuntu/trusty'}}
+    >>> config = {'name': 'my-container', 'source': {'type': 'image', 'alias': 'ubuntu/trusty'}}
     >>> container = client.containers.create(config, wait=True)
     >>> container.start()
     >>> container.freeze()


### PR DESCRIPTION
When creating a container the documentation stated that config source type should be image and an image key should be present to define the image. However this should be {'type': 'image', 'alias': '...'}.