### PR TITLE
Added description to container.

### DIFF
--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -56,6 +56,7 @@ class Container(model.Model):
     expanded_config = model.Attribute()
     expanded_devices = model.Attribute()
     name = model.Attribute(readonly=True)
+    description = model.Attribute()
     profiles = model.Attribute()
     status = model.Attribute(readonly=True)
     last_used_at = model.Attribute(readonly=True)


### PR DESCRIPTION
This is to fix a bug I was regularly seeing when pulling attributes of a container:

`AttributeError: 'Container' object has no attribute 'description'`