### PR TITLE
Fix broken CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - test -d .tox/$TOXENV/log && cat .tox/$TOXENV/log/*.log || true
 cache:
   directories:
-    - .tox/$TOXENV
     - $HOME/.cache/pip
 after_success:
   - codecov

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -185,6 +185,7 @@ RULES = [
                 },
                 'created_at': "1983-06-16T00:00:00-00:00",
                 'last_used_at': "1983-06-16T00:00:00-00:00",
+                'description': "Some description",
                 'devices': {
                     'root': {
                         'path': "/",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.2
+version = 2.2.4
 description-file =
     README.rst
 author = Paul Hummer

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,6 @@ mock>=1.3.0
 flake8>=2.5.0
 coverage>=4.1
 mock-services>=0.3
+# mock-services is old and unmaintained. Doesn't work with newer versions of
+# requests-mock. Thus, we have to pin it down.
+requests-mock<1.2


### PR DESCRIPTION
The whole test suite was broken lately for three reasons:

1. Version in `setp.cfg` was out of sync with git tagging, making `pbr`
   scream.
2. `mock_services` is outdated and unmaintained and doesn't work with
   newer versions of `requests-mock`.
3. The newly added `description` property wasn't properly added in
   mocked LXD.

I've fixed those two problems by updating the `setup.cfg` version,
pinning `requests-mock` to the last version to work and adding a
`description` field to the mocks.

On my machine, all tox tests pass now.