### PR TITLE
Make models resilient to new attributes in LXD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - test -d .tox/$TOXENV/log && cat .tox/$TOXENV/log/*.log || true
 cache:
   directories:
-    - .tox/$TOXENV
     - $HOME/.cache/pip
 after_success:
   - codecov

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -151,8 +151,13 @@ class Model(object):
         response = self.api.get()
         for key, val in response.json()['metadata'].items():
             if key not in self.__dirty__ or rollback:
-                setattr(self, key, val)
-                self.__dirty__.remove(key)
+                try:
+                    setattr(self, key, val)
+                    self.__dirty__.remove(key)
+                except AttributeError:
+                    # We have received an attribute from the server that we don't support
+                    # in our model. Ignore this error, it doesn't hurt us.
+                    pass
         if rollback:
             self.__dirty__.clear()
 

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -18,6 +18,9 @@ import six
 from pylxd import exceptions
 
 
+MISSING = object()
+
+
 class Attribute(object):
     """A metadata class for model attributes."""
 
@@ -149,7 +152,8 @@ class Model(object):
         # XXX: rockstar (25 Jun 2016) - This has the potential to step
         # on existing attributes.
         response = self.api.get()
-        for key, val in response.json()['metadata'].items():
+        payload = response.json()['metadata']
+        for key, val in payload.items():
             if key not in self.__dirty__ or rollback:
                 try:
                     setattr(self, key, val)
@@ -159,6 +163,12 @@ class Model(object):
                     # don't support in our model. Ignore this error, it
                     # doesn't hurt us.
                     pass
+
+        # Make sure that *all* supported attributes are set, even those that
+        # aren't supported by the server.
+        missing_attrs = set(self.__attributes__.keys()) - set(payload.keys())
+        for missing_attr in missing_attrs:
+            setattr(self, missing_attr, MISSING)
         if rollback:
             self.__dirty__.clear()
 
@@ -193,8 +203,12 @@ class Model(object):
     def marshall(self):
         """Marshall the object in preparation for updating to the server."""
         marshalled = {}
-        for key, val in self.__attributes__.items():
-            if ((not val.readonly and not val.optional) or
-                    (val.optional and hasattr(self, key))):
-                marshalled[key] = getattr(self, key)
+        for key, attr in self.__attributes__.items():
+            if ((not attr.readonly and not attr.optional) or
+                    (attr.optional and hasattr(self, key))):
+                val = getattr(self, key)
+                # Don't send back to the server an attribute it doesn't
+                # support.
+                if val is not MISSING:
+                    marshalled[key] = val
         return marshalled

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -155,8 +155,9 @@ class Model(object):
                     setattr(self, key, val)
                     self.__dirty__.remove(key)
                 except AttributeError:
-                    # We have received an attribute from the server that we don't support
-                    # in our model. Ignore this error, it doesn't hurt us.
+                    # We have received an attribute from the server that we
+                    # don't support in our model. Ignore this error, it
+                    # doesn't hurt us.
                     pass
         if rollback:
             self.__dirty__.clear()

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -185,6 +185,7 @@ RULES = [
                 },
                 'created_at': "1983-06-16T00:00:00-00:00",
                 'last_used_at': "1983-06-16T00:00:00-00:00",
+                'description': "Some description",
                 'devices': {
                     'root': {
                         'path': "/",

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -213,7 +213,8 @@ RULES = [
                 ],
                 'stateful': False,
                 'status': "Running",
-                'status_code': 103
+                'status_code': 103,
+                'unsupportedbypylxd': "This attribute is not supported by pylxd. We want to test whether the mere presence of it makes it crash."
             }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -214,7 +214,9 @@ RULES = [
                 'stateful': False,
                 'status': "Running",
                 'status_code': 103,
-                'unsupportedbypylxd': "This attribute is not supported by pylxd. We want to test whether the mere presence of it makes it crash."
+                'unsupportedbypylxd': "This attribute is not supported by "\
+                    "pylxd. We want to test whether the mere presence of it "\
+                    "makes it crash."
             }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.2
+version = 2.2.4
 description-file =
     README.rst
 author = Paul Hummer

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,6 @@ mock>=1.3.0
 flake8>=2.5.0
 coverage>=4.1
 mock-services>=0.3
+# mock-services is old and unmaintained. Doesn't work with newer versions of
+# requests-mock. Thus, we have to pin it down.
+requests-mock<1.2


### PR DESCRIPTION
It's been a few times now (ref #188, #230) where we're in a tricky situation because a new attribute in LXD makes pylxd crash. It's not fun because it makes us *have* to update pylxd and LXD at the same time.

This commit makes models ignore `AttributeError` during `sync()`, which should normally fix this problem once and for all.

Depends on #233