### PR TITLE
timeout kwarg for client object

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -101,23 +101,17 @@ class _APINode(object):
 
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        try:
-            _timeout = kwargs.pop('timeout')
-        except KeyError:
-            _timeout = self._timeout
+        kwargs['timeout'] = kwargs.get('timeout', self._timeout)
         response = self.session.get(
-            self._api_endpoint, *args, timeout=_timeout, **kwargs)
+            self._api_endpoint, *args, **kwargs)
         self._assert_response(response, stream=kwargs.get('stream', False))
         return response
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
-        try:
-            _timeout = kwargs.pop('timeout')
-        except KeyError:
-            _timeout = self._timeout
+        kwargs['timeout'] = kwargs.get('timeout', self._timeout)
         response = self.session.post(
-            self._api_endpoint, *args, timeout=_timeout, **kwargs)
+            self._api_endpoint, *args, **kwargs)
         # Prior to LXD 2.0.3, successful synchronous requests returned 200,
         # rather than 201.
         self._assert_response(response, allowed_status_codes=(200, 201, 202))
@@ -125,23 +119,17 @@ class _APINode(object):
 
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
-        try:
-            _timeout = kwargs.pop('timeout')
-        except KeyError:
-            _timeout = self._timeout
+        kwargs['timeout'] = kwargs.get('timeout', self._timeout)
         response = self.session.put(
-            self._api_endpoint, *args, timeout=_timeout, **kwargs)
+            self._api_endpoint, *args, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
-        try:
-            _timeout = kwargs.pop('timeout')
-        except KeyError:
-            _timeout = self._timeout
+        kwargs['timeout'] = kwargs.get('timeout', self._timeout)
         response = self.session.delete(
-            self._api_endpoint, *args, timeout=_timeout, **kwargs)
+            self._api_endpoint, *args, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -102,16 +102,14 @@ class _APINode(object):
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
         kwargs['timeout'] = kwargs.get('timeout', self._timeout)
-        response = self.session.get(
-            self._api_endpoint, *args, **kwargs)
+        response = self.session.get(self._api_endpoint, *args, **kwargs)
         self._assert_response(response, stream=kwargs.get('stream', False))
         return response
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
         kwargs['timeout'] = kwargs.get('timeout', self._timeout)
-        response = self.session.post(
-            self._api_endpoint, *args, **kwargs)
+        response = self.session.post(self._api_endpoint, *args, **kwargs)
         # Prior to LXD 2.0.3, successful synchronous requests returned 200,
         # rather than 201.
         self._assert_response(response, allowed_status_codes=(200, 201, 202))
@@ -120,16 +118,14 @@ class _APINode(object):
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
         kwargs['timeout'] = kwargs.get('timeout', self._timeout)
-        response = self.session.put(
-            self._api_endpoint, *args, **kwargs)
+        response = self.session.put(self._api_endpoint, *args, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
         kwargs['timeout'] = kwargs.get('timeout', self._timeout)
-        response = self.session.delete(
-            self._api_endpoint, *args, **kwargs)
+        response = self.session.delete(self._api_endpoint, *args, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -89,9 +89,6 @@ class _APINode(object):
                 # Missing 'type' in response
                 raise exceptions.LXDAPIException(response)
 
-    def _req_timeout(self, req_timeout):
-        return req_timeout if req_timeout is not None else self._timeout
-
     @property
     def scheme(self):
         return parse.urlparse(self.api._api_endpoint).scheme
@@ -102,7 +99,10 @@ class _APINode(object):
 
     def get(self, *args, **kwargs):
         """Perform an HTTP GET."""
-        _timeout=self._req_timeout(kwargs.get('timeout'))
+        try:
+            _timeout = kwargs.pop('timeout')
+        except KeyError:
+            _timeout = self._timeout
         response = self.session.get(
             self._api_endpoint, *args, timeout=_timeout, **kwargs)
         self._assert_response(response, stream=kwargs.get('stream', False))
@@ -110,7 +110,10 @@ class _APINode(object):
 
     def post(self, *args, **kwargs):
         """Perform an HTTP POST."""
-        _timeout=self._req_timeout(kwargs.get('timeout'))
+        try:
+            _timeout = kwargs.pop('timeout')
+        except KeyError:
+            _timeout = self._timeout
         response = self.session.post(self._api_endpoint, *args, timeout=_timeout, **kwargs)
         # Prior to LXD 2.0.3, successful synchronous requests returned 200,
         # rather than 201.
@@ -119,14 +122,20 @@ class _APINode(object):
 
     def put(self, *args, **kwargs):
         """Perform an HTTP PUT."""
-        _timeout=self._req_timeout(kwargs.get('timeout'))
+        try:
+            _timeout = kwargs.pop('timeout')
+        except KeyError:
+            _timeout = self._timeout
         response = self.session.put(self._api_endpoint, *args, timeout=_timeout, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 
     def delete(self, *args, **kwargs):
         """Perform an HTTP delete."""
-        _timeout=self._req_timeout(kwargs.get('timeout'))
+        try:
+            _timeout = kwargs.pop('timeout')
+        except KeyError:
+            _timeout = self._timeout
         response = self.session.delete(self._api_endpoint, *args, timeout=_timeout, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -52,7 +52,9 @@ class _APINode(object):
     def __getitem__(self, item):
         return self.__class__(
             '{}/{}'.format(self._api_endpoint, item),
-            cert=self.session.cert, verify=self.session.verify, timeout=self._timeout)
+            cert=self.session.cert,
+            verify=self.session.verify,
+            timeout=self._timeout)
 
     def _assert_response(
             self, response, allowed_status_codes=(200,), stream=False):
@@ -114,7 +116,8 @@ class _APINode(object):
             _timeout = kwargs.pop('timeout')
         except KeyError:
             _timeout = self._timeout
-        response = self.session.post(self._api_endpoint, *args, timeout=_timeout, **kwargs)
+        response = self.session.post(
+            self._api_endpoint, *args, timeout=_timeout, **kwargs)
         # Prior to LXD 2.0.3, successful synchronous requests returned 200,
         # rather than 201.
         self._assert_response(response, allowed_status_codes=(200, 201, 202))
@@ -126,7 +129,8 @@ class _APINode(object):
             _timeout = kwargs.pop('timeout')
         except KeyError:
             _timeout = self._timeout
-        response = self.session.put(self._api_endpoint, *args, timeout=_timeout, **kwargs)
+        response = self.session.put(
+            self._api_endpoint, *args, timeout=_timeout, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 
@@ -136,7 +140,8 @@ class _APINode(object):
             _timeout = kwargs.pop('timeout')
         except KeyError:
             _timeout = self._timeout
-        response = self.session.delete(self._api_endpoint, *args, timeout=_timeout, **kwargs)
+        response = self.session.delete(
+            self._api_endpoint, *args, timeout=_timeout, **kwargs)
         self._assert_response(response, allowed_status_codes=(200, 202))
         return response
 
@@ -204,7 +209,9 @@ class Client(object):
         os.path.expanduser('~/.config/lxc/client.crt'),
         os.path.expanduser('~/.config/lxc/client.key'))
 
-    def __init__(self, endpoint=None, version='1.0', cert=None, verify=True, timeout=None):
+    def __init__(
+            self, endpoint=None, version='1.0', cert=None, verify=True,
+            timeout=None):
         self.cert = cert
         if endpoint is not None:
             if endpoint.startswith('/') and os.path.isfile(endpoint):
@@ -217,7 +224,8 @@ class Client(object):
                         os.path.exists(self.DEFAULT_CERTS[0]) and
                         os.path.exists(self.DEFAULT_CERTS[1])):
                     cert = self.DEFAULT_CERTS
-                self.api = _APINode(endpoint, cert=cert, verify=verify, timeout=timeout)
+                self.api = _APINode(
+                    endpoint, cert=cert, verify=verify, timeout=timeout)
         else:
             if 'LXD_DIR' in os.environ:
                 path = os.path.join(

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -199,7 +199,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('ws+unix:///lxd/unix.socket', timeout=None)
+        WebsocketClient.assert_called_once_with('ws+unix:///lxd/unix.socket')
 
     @requires_ws4py
     def test_events_htt(self):
@@ -211,7 +211,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('ws://lxd.local', timeout=None)
+        WebsocketClient.assert_called_once_with('ws://lxd.local')
 
     @requires_ws4py
     def test_events_https(self):
@@ -223,7 +223,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('wss://lxd.local', timeout=None)
+        WebsocketClient.assert_called_once_with('wss://lxd.local')
 
 
 class TestAPINode(unittest.TestCase):

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -199,7 +199,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('ws+unix:///lxd/unix.socket')
+        WebsocketClient.assert_called_once_with('ws+unix:///lxd/unix.socket', timeout=None)
 
     @requires_ws4py
     def test_events_htt(self):
@@ -211,7 +211,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('ws://lxd.local')
+        WebsocketClient.assert_called_once_with('ws://lxd.local', timeout=None)
 
     @requires_ws4py
     def test_events_https(self):
@@ -223,7 +223,7 @@ class TestClient(unittest.TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with('wss://lxd.local')
+        WebsocketClient.assert_called_once_with('wss://lxd.local', timeout=None)
 
 
 class TestAPINode(unittest.TestCase):
@@ -273,7 +273,7 @@ class TestAPINode(unittest.TestCase):
 
         node.get()
 
-        session.get.assert_called_once_with('http://test.com')
+        session.get.assert_called_once_with('http://test.com', timeout=None)
 
     @mock.patch('pylxd.client.requests.Session')
     def test_post(self, Session):
@@ -289,7 +289,7 @@ class TestAPINode(unittest.TestCase):
 
         node.post()
 
-        session.post.assert_called_once_with('http://test.com')
+        session.post.assert_called_once_with('http://test.com', timeout=None)
 
     @mock.patch('pylxd.client.requests.Session')
     def test_post_200_not_sync(self, Session):
@@ -337,7 +337,7 @@ class TestAPINode(unittest.TestCase):
 
         node.put()
 
-        session.put.assert_called_once_with('http://test.com')
+        session.put.assert_called_once_with('http://test.com', timeout=None)
 
     @mock.patch('pylxd.client.requests.Session')
     def test_delete(self, Session):
@@ -353,7 +353,7 @@ class TestAPINode(unittest.TestCase):
 
         node.delete()
 
-        session.delete.assert_called_once_with('http://test.com')
+        session.delete.assert_called_once_with('http://test.com', timeout=None)
 
 
 class TestWebsocketClient(unittest.TestCase):


### PR DESCRIPTION
Added request timeout kwarg for Client -> _APINode instance + possibility to set custom timeout for each get/post/put/delete

problem: for now pylxd have no request timeout, so on busy servers or if firewall drops request - pylxd client may hang forever

fix: pass timeout kwarg when initializing client object to set global timeout for requests. By default timeout set to None (backwards compatibility)

usage:
* set client timeout (connect, read) for all requests:
`cli = pylxd.Client(endpoint=..., ..., timeout=1)`
* set client connect timeout to 1s and client read timeout to 2s for all requests:
`cli = pylxd.Client(endpoint=..., ..., timeout=(1, 2))`
* redefine client timeout for current request to 1000s:
```
cli = pylxd.Client(endpoint=..., ..., timeout=1)
cli.api.get(timeout=1000)
```
