### PR TITLE
Fix memory hog during image import

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,32 +4,33 @@ Contributors to pylxd
 
 These are the contributors to pylxd according to the Github repository.
 
- =============== ==================================
- GH username      Name
- =============== ==================================
- rockstar        Paul Hummer
- zulcss          Chuck Short
- saviq           Michał Sawicz
- javacruft       James Page (Canonical)
- pcdummy         Rene Jochum
- jpic            ???
- hsoft           Virgil Dupras
- mgwilliams      Matthew Williams
- tych0           Tycho Andersen (Canonical)
- aarnaud         Anthony Arnaud
- moreati         Alex Willmer
- uglide          Igor Malinovskiy
- Itxaka          ???
- ivuk            Igor Vuk
- reversecipher   ???
- stgraber        Stéphane Graber (Canonical)
- toshism         Tosh Lyons
- om26er          Omer Akram
- sergiusens      Sergio Schvezov
- datashaman      ???
- rooty0          ???
- jimmymccrory    Jimmy McCrory
- Synforge        Paul Oyston
- overquota       ???
- =============== ==================================
+ ===============  ==================================
+ GHsername        Name
+ ===============  ==================================
+ rockstar         Paul Hummer
+ zulcss           Chuck Short
+ saviq            Michał Sawicz
+ javacruft        James Page (Canonical)
+ pcdummy          Rene Jochum
+ jpic             ???
+ hsoft            Virgil Dupras
+ mgwilliams       Matthew Williams
+ tych0            Tycho Andersen (Canonical)
+ aarnaud          Anthony Arnaud
+ moreati          Alex Willmer
+ uglide           Igor Malinovskiy
+ Itxaka           ???
+ ivuk             Igor Vuk
+ reversecipher    ???
+ stgraber         Stéphane Graber (Canonical)
+ toshism          Tosh Lyons
+ om26er           Omer Akram
+ sergiusens       Sergio Schvezov
+ datashaman       ???
+ rooty0           ???
+ jimmymccrory     Jimmy McCrory
+ Synforge         Paul Oyston
+ overquota        ???
+ chrismacnaughton Chris MacNaughton
+ ===============  ==================================
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -219,10 +219,7 @@ class Client(object):
                 path = os.path.join(
                     os.environ.get('LXD_DIR'), 'unix.socket')
             else:
-                if os.path.exists('/var/snap/lxd/common/lxd/unix.socket'):
-                    path = '/var/snap/lxd/common/lxd/unix.socket'
-                else:
-                    path = '/var/lib/lxd/unix.socket'
+                path = '/var/lib/lxd/unix.socket'
             self.api = _APINode('http+unix://{}'.format(
                 parse.quote(path, safe='')), timeout=timeout)
         self.api = self.api[version]

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -219,7 +219,10 @@ class Client(object):
                 path = os.path.join(
                     os.environ.get('LXD_DIR'), 'unix.socket')
             else:
-                path = '/var/lib/lxd/unix.socket'
+                if os.path.exists('/var/snap/lxd/common/lxd/unix.socket'):
+                    path = '/var/snap/lxd/common/lxd/unix.socket'
+                else:
+                    path = '/var/lib/lxd/unix.socket'
             self.api = _APINode('http+unix://{}'.format(
                 parse.quote(path, safe='')), timeout=timeout)
         self.api = self.api[version]

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -45,13 +45,17 @@ class _APINode(object):
             self.session.verify = verify
 
     def __getattr__(self, name):
+        # name here correspoinds to the model name in the LXD API
+        # and, as such, must have underscores replaced with hyphens
         return self.__class__(
-            '{}/{}'.format(self._api_endpoint, name),
+            '{}/{}'.format(self._api_endpoint, name.replace('_', '-')),
             cert=self.session.cert, verify=self.session.verify)
 
     def __getitem__(self, item):
+        # item here correspoinds to the model name in the LXD API
+        # and, as such, must have underscores replaced with hyphens
         return self.__class__(
-            '{}/{}'.format(self._api_endpoint, item),
+            '{}/{}'.format(self._api_endpoint, item.replace('_', '-')),
             cert=self.session.cert,
             verify=self.session.verify,
             timeout=self._timeout)
@@ -237,6 +241,7 @@ class Client(object):
         self.networks = managers.NetworkManager(self)
         self.operations = managers.OperationManager(self)
         self.profiles = managers.ProfileManager(self)
+        self.storage_pools = managers.StoragePoolManager(self)
 
     @property
     def trusted(self):

--- a/pylxd/managers.py
+++ b/pylxd/managers.py
@@ -55,6 +55,10 @@ class SnapshotManager(BaseManager):
     manager_for = 'pylxd.models.Snapshot'
 
 
+class StoragePoolManager(BaseManager):
+    manager_for = 'pylxd.models.StoragePool'
+
+
 @contextmanager
 def web_socket_manager(manager):
     try:

--- a/pylxd/models/__init__.py
+++ b/pylxd/models/__init__.py
@@ -4,3 +4,4 @@ from pylxd.models.image import Image  # NOQA
 from pylxd.models.network import Network  # NOQA
 from pylxd.models.operation import Operation  # NOQA
 from pylxd.models.profile import Profile  # NOQA
+from pylxd.models.storage_pool import StoragePool  # NOQA

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -360,6 +360,7 @@ class Snapshot(model.Model):
     """A container snapshot."""
 
     name = model.Attribute()
+    created_at = model.Attribute()
     stateful = model.Attribute()
 
     container = model.Parent()

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -122,7 +122,7 @@ class Image(model.Model):
         if public:
             headers['X-LXD-Public'] = '1'
 
-        if from_streams is not None:
+        if from_streams:
             # Image uploaded as chunked/stream (metadata, rootfs)
             # multipart message.
             # Order of parts is important metadata should be passed first

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -123,8 +123,9 @@ class Image(model.Model):
             headers['X-LXD-Public'] = '1'
 
         if from_streams is not None:
-            # Image uploaded as streamed (metadata, rootfs) multipart message
-            # order is important metadata should be passed first
+            # Image uploaded as chunked/stream (metadata, rootfs)
+            # multipart message.
+            # Order of parts is important metadata should be passed first
             files = collections.OrderedDict(
                 metadata=('metadata', metadata, 'application/octet-stream'),
                 rootfs=('rootfs', image_data, 'application/octet-stream'))

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -155,8 +155,7 @@ class Image(model.Model):
         else:
             data = image_data
 
-        response = client.api.images.post(
-            data=data, files=None, headers=headers)
+        response = client.api.images.post(data=data, headers=headers)
         operation = client.operations.wait_for_operation(
             response.json()['operation'])
         return cls(client, fingerprint=operation.metadata['fingerprint'])

--- a/pylxd/models/storage_pool.py
+++ b/pylxd/models/storage_pool.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from pylxd.models import _model as model
+
+
+class StoragePool(model.Model):
+    """A LXD storage_pool.
+
+    This corresponds to the LXD endpoint at
+    /1.0/storage-pools
+    """
+    name = model.Attribute()
+    driver = model.Attribute()
+    description = model.Attribute()
+    used_by = model.Attribute()
+    config = model.Attribute()
+    managed = model.Attribute()
+
+    @classmethod
+    def get(cls, client, name):
+        """Get a storage_pool by name."""
+        response = client.api.storage_pools[name].get()
+
+        storage_pool = cls(client, **response.json()['metadata'])
+        return storage_pool
+
+    @classmethod
+    def all(cls, client):
+        """Get all storage_pools."""
+        response = client.api.storage_pools.get()
+
+        storage_pools = []
+        for url in response.json()['metadata']:
+            name = url.split('/')[-1]
+            storage_pools.append(cls(client, name=name))
+        return storage_pools
+
+    @property
+    def api(self):
+        return self.client.api.storage_pools[self.name]
+
+    def save(self, wait=False):
+        """Save is not available for storage_pools."""
+        raise NotImplementedError('save is not implemented')
+
+    def delete(self):
+        """Delete is not available for storage_pools."""
+        raise NotImplementedError('delete is not implemented')

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -545,6 +545,32 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/networks/lo$',
     },
 
+    # Storage Pools
+    {
+        'json': {
+            'type': 'sync',
+            'metadata': [
+                'http://pylxd.test/1.0/storage-pools/lxd',
+            ]},
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/storage-pools$',
+    },
+    {
+        'json': {
+            'type': 'sync',
+            'metadata': {
+                'config': {
+                    'size': '0',
+                    'source': '/var/lib/lxd/disks/lxd.img'
+                },
+                'description': '',
+                'name': 'lxd',
+                'driver': 'zfs',
+                'used_by': [],
+            }},
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/storage-pools/lxd$',
+    },
 
     # Profiles
     {

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 
+from io import StringIO
 from pylxd import exceptions, models
 from pylxd.tests import testing
 
@@ -111,6 +112,16 @@ class TestImage(testing.PyLXDTestCase):
         fingerprint = hashlib.sha256(b'').hexdigest()
         a_image = models.Image.create(
             self.client, b'', metadata=b'', public=True, wait=True)
+
+        self.assertIsInstance(a_image, models.Image)
+        self.assertEqual(fingerprint, a_image.fingerprint)
+
+    def test_create_with_metadata_from_streams(self):
+        """An image with metadata is created."""
+        fingerprint = hashlib.sha256(b'').hexdigest()
+        a_image = models.Image.create(
+            self.client, StringIO(u''), metadata=StringIO(u''),
+            public=True, wait=True, from_streams=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)

--- a/pylxd/tests/models/test_storage.py
+++ b/pylxd/tests/models/test_storage.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from pylxd import models
+from pylxd.tests import testing
+
+
+class TestStoragePool(testing.PyLXDTestCase):
+    """Tests for pylxd.models.StoragePool."""
+
+    def test_all(self):
+        """A list of all storage_pools are returned."""
+        storage_pools = models.StoragePool.all(self.client)
+
+        self.assertEqual(1, len(storage_pools))
+
+    def test_get(self):
+        """Return a container."""
+        name = 'lxd'
+
+        an_storage_pool = models.StoragePool.get(self.client, name)
+
+        self.assertEqual(name, an_storage_pool.name)
+
+    def test_partial(self):
+        """A partial storage_pool is synced."""
+        an_storage_pool = models.StoragePool(self.client, name='lxd')
+
+        self.assertEqual('zfs', an_storage_pool.driver)
+
+    def test_delete(self):
+        """delete is not implemented in storage_pools."""
+        an_storage_pool = models.StoragePool(self.client, name='lxd')
+
+        with self.assertRaises(NotImplementedError):
+            an_storage_pool.delete()
+
+    def test_save(self):
+        """save is not implemented in storage_pools."""
+        an_storage_pool = models.StoragePool(self.client, name='lxd')
+
+        with self.assertRaises(NotImplementedError):
+            an_storage_pool.save()

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -48,10 +48,8 @@ class TestClient(unittest.TestCase):
         self.get_patcher.stop()
         self.post_patcher.stop()
 
-    @mock.patch('os.path.exists')
-    def test_create(self, _path_exists):
+    def test_create(self):
         """Client creation sets default API endpoint."""
-        _path_exists.return_value = False
         expected = 'http+unix://%2Fvar%2Flib%2Flxd%2Funix.socket/1.0'
 
         an_client = client.Client()

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -48,8 +48,10 @@ class TestClient(unittest.TestCase):
         self.get_patcher.stop()
         self.post_patcher.stop()
 
-    def test_create(self):
+    @mock.patch('os.path.exists')
+    def test_create(self, _path_exists):
         """Client creation sets default API endpoint."""
+        _path_exists.return_value = False
         expected = 'http+unix://%2Fvar%2Flib%2Flxd%2Funix.socket/1.0'
 
         an_client = client.Client()

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -48,12 +48,25 @@ class TestClient(unittest.TestCase):
         self.get_patcher.stop()
         self.post_patcher.stop()
 
-    def test_create(self):
+    @mock.patch('os.path.exists')
+    def test_create(self, _path_exists):
         """Client creation sets default API endpoint."""
+        _path_exists.return_value = False
         expected = 'http+unix://%2Fvar%2Flib%2Flxd%2Funix.socket/1.0'
 
         an_client = client.Client()
 
+        self.assertEqual(expected, an_client.api._api_endpoint)
+
+    @mock.patch('os.path.exists')
+    @mock.patch('os.environ')
+    def test_create_with_snap_lxd(self, _environ, _path_exists):
+        # """Client creation sets default API endpoint."""
+        _path_exists.return_value = True
+        expected = ('http+unix://%2Fvar%2Fsnap%2Flxd%2F'
+                    'common%2Flxd%2Funix.socket/1.0')
+
+        an_client = client.Client()
         self.assertEqual(expected, an_client.api._api_endpoint)
 
     def test_create_LXD_DIR(self):
@@ -195,6 +208,7 @@ class TestClient(unittest.TestCase):
         websocket_client = mock.Mock(resource=None)
         WebsocketClient = mock.Mock()
         WebsocketClient.return_value = websocket_client
+        os.environ['LXD_DIR'] = '/lxd'
         an_client = client.Client()
 
         an_client.events(websocket_client=WebsocketClient)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ six>=1.9.0
 ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,!=2.12.0,!=2.12.1,>=2.5.2
 requests-unixsocket>=0.1.5
+requests-toolbelt>=0.8.0
 cryptography!=1.3.0,>=1.0
 pyOpenSSL>=0.14;python_version<='2.7.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.4
+version = 2.2.5
 description-file =
     README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)


### PR DESCRIPTION
Existing version load image into memory when non-unified image used
(with separate tarball with manifest).
Added ability for stream based image upload without loading them to memory.
requests-toolbelt external package required for streaming multipart HTTP
image upload.
Additional parameter added to identify if streams are/can be passed - this will allow
pylxd client to identify via introspection if pylxd library supports stream based
upload and fallback to old non-stream behavior if old version of pylxd is installed.