### PR TITLE
Image import - memory hog fix

### DIFF
--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -122,7 +122,7 @@ class Image(model.Model):
         if public:
             headers['X-LXD-Public'] = '1'
 
-        if from_streams is not None:
+        if from_streams:
             # Image uploaded as chunked/stream (metadata, rootfs)
             # multipart message.
             # Order of parts is important metadata should be passed first

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -123,8 +123,9 @@ class Image(model.Model):
             headers['X-LXD-Public'] = '1'
 
         if from_streams is not None:
-            # Image uploaded as streamed (metadata, rootfs) multipart message
-            # order is important metadata should be passed first
+            # Image uploaded as chunked/stream (metadata, rootfs)
+            # multipart message.
+            # Order of parts is important metadata should be passed first
             files = collections.OrderedDict(
                 metadata=('metadata', metadata, 'application/octet-stream'),
                 rootfs=('rootfs', image_data, 'application/octet-stream'))

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -155,8 +155,7 @@ class Image(model.Model):
         else:
             data = image_data
 
-        response = client.api.images.post(
-            data=data, files=None, headers=headers)
+        response = client.api.images.post(data=data, headers=headers)
         operation = client.operations.wait_for_operation(
             response.json()['operation'])
         return cls(client, fingerprint=operation.metadata['fingerprint'])

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -111,17 +111,8 @@ class TestImage(testing.PyLXDTestCase):
         """An image with metadata is created."""
         fingerprint = hashlib.sha256(b'').hexdigest()
         a_image = models.Image.create(
-            self.client, b'', metadata=b'', public=True, wait=True)
-
-        self.assertIsInstance(a_image, models.Image)
-        self.assertEqual(fingerprint, a_image.fingerprint)
-
-    def test_create_with_metadata_from_streams(self):
-        """An image with metadata is created."""
-        fingerprint = hashlib.sha256(b'').hexdigest()
-        a_image = models.Image.create(
             self.client, StringIO(u''), metadata=StringIO(u''),
-            public=True, wait=True, from_streams=True)
+            public=True, wait=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -111,6 +111,15 @@ class TestImage(testing.PyLXDTestCase):
         """An image with metadata is created."""
         fingerprint = hashlib.sha256(b'').hexdigest()
         a_image = models.Image.create(
+            self.client, b'', metadata=b'', public=True, wait=True)
+
+        self.assertIsInstance(a_image, models.Image)
+        self.assertEqual(fingerprint, a_image.fingerprint)
+
+    def test_create_with_metadata_streamed(self):
+        """An image with metadata is created."""
+        fingerprint = hashlib.sha256(b'').hexdigest()
+        a_image = models.Image.create(
             self.client, StringIO(u''), metadata=StringIO(u''),
             public=True, wait=True)
 

--- a/pylxd/tests/models/test_image.py
+++ b/pylxd/tests/models/test_image.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 
+from io import StringIO
 from pylxd import exceptions, models
 from pylxd.tests import testing
 
@@ -111,6 +112,16 @@ class TestImage(testing.PyLXDTestCase):
         fingerprint = hashlib.sha256(b'').hexdigest()
         a_image = models.Image.create(
             self.client, b'', metadata=b'', public=True, wait=True)
+
+        self.assertIsInstance(a_image, models.Image)
+        self.assertEqual(fingerprint, a_image.fingerprint)
+
+    def test_create_with_metadata_from_streams(self):
+        """An image with metadata is created."""
+        fingerprint = hashlib.sha256(b'').hexdigest()
+        a_image = models.Image.create(
+            self.client, StringIO(u''), metadata=StringIO(u''),
+            public=True, wait=True, from_streams=True)
 
         self.assertIsInstance(a_image, models.Image)
         self.assertEqual(fingerprint, a_image.fingerprint)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ six>=1.9.0
 ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,!=2.12.0,!=2.12.1,>=2.5.2
 requests-unixsocket>=0.1.5
+requests-toolbelt>=0.8.0
 cryptography!=1.3.0,>=1.0
 pyOpenSSL>=0.14;python_version<='2.7.8'


### PR DESCRIPTION
Existing version load image into memory when non-unified image used
(with separate tarball with manifest).
Added ability for stream based image upload without loading them to memory.
requests-toolbelt external package required for streaming multipart HTTP
image upload.