### PR TITLE
Update cert check to look in snap path as well

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -33,15 +33,16 @@ requests_unixsocket.monkeypatch()
 LXD_PATH = '.config/lxc/'
 SNAP_ROOT = '~/snap/lxd/current/'
 APT_ROOT = '~/'
-if os.path.exists(os.path.expanduser(SNAP_ROOT)):
-    CERTS_PATH = os.path.join(SNAP_ROOT, LXD_PATH)
-else:
-    CERTS_PATH = os.path.join(APT_ROOT, LXD_PATH)
+if os.path.exists(os.path.expanduser(SNAP_ROOT)):  # pragma: no cover
+    CERTS_PATH = os.path.join(SNAP_ROOT, LXD_PATH)  # pragma: no cover
+else:  # pragma: no cover
+    CERTS_PATH = os.path.join(APT_ROOT, LXD_PATH)  # pragma: no cover
 
-Cert = namedtuple('Cert', ['cert', 'key'])
+Cert = namedtuple('Cert', ['cert', 'key'])  # pragma: no cover
 DEFAULT_CERTS = Cert(
     cert=os.path.expanduser(os.path.join(CERTS_PATH, 'client.crt')),
-    key=os.path.expanduser(os.path.join(CERTS_PATH, 'client.key')))
+    key=os.path.expanduser(os.path.join(CERTS_PATH, 'client.key'))
+)  # pragma: no cover
 
 
 class _APINode(object):

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -29,6 +29,17 @@ from pylxd import exceptions, managers
 
 requests_unixsocket.monkeypatch()
 
+LXD_PATH = '.config/lxc/'
+SNAP_ROOT = '~/snap/lxd/current/'
+APT_ROOT = '~/'
+if os.path.exists(os.path.expanduser(SNAP_ROOT)):
+    CERTS_PATH = "{}{}".format(SNAP_ROOT, LXD_PATH)
+else:
+    CERTS_PATH = "{}{}".format(APT_ROOT, LXD_PATH)
+DEFAULT_CERTS = (
+    os.path.expanduser('{}client.crt'.format(CERTS_PATH)),
+    os.path.expanduser('{}client.key'.format(CERTS_PATH)))
+
 
 class _APINode(object):
     """An api node object."""
@@ -192,15 +203,6 @@ class Client(object):
             >>> print api.containers['test'].get().json()
 
     """
-    if os.path.exists(
-            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.crt')):
-        DEFAULT_CERTS = (
-            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.crt'),
-            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.key'))
-    else:
-        DEFAULT_CERTS = (
-            os.path.expanduser('~/.config/lxc/client.crt'),
-            os.path.expanduser('~/.config/lxc/client.key'))
 
     def __init__(
             self, endpoint=None, version='1.0', cert=None, verify=True,
@@ -214,9 +216,9 @@ class Client(object):
                 # Extra trailing slashes cause LXD to 301
                 endpoint = endpoint.rstrip('/')
                 if cert is None and (
-                        os.path.exists(self.DEFAULT_CERTS[0]) and
-                        os.path.exists(self.DEFAULT_CERTS[1])):
-                    cert = self.DEFAULT_CERTS
+                        os.path.exists(DEFAULT_CERTS[0]) and
+                        os.path.exists(DEFAULT_CERTS[1])):
+                    cert = DEFAULT_CERTS
                 self.api = _APINode(
                     endpoint, cert=cert, verify=verify, timeout=timeout)
         else:

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -14,6 +14,7 @@
 import json
 import os
 import os.path
+from collections import namedtuple
 
 import requests
 import requests_unixsocket
@@ -33,12 +34,14 @@ LXD_PATH = '.config/lxc/'
 SNAP_ROOT = '~/snap/lxd/current/'
 APT_ROOT = '~/'
 if os.path.exists(os.path.expanduser(SNAP_ROOT)):
-    CERTS_PATH = "{}{}".format(SNAP_ROOT, LXD_PATH)
+    CERTS_PATH = os.path.join(SNAP_ROOT, LXD_PATH)
 else:
-    CERTS_PATH = "{}{}".format(APT_ROOT, LXD_PATH)
-DEFAULT_CERTS = (
-    os.path.expanduser('{}client.crt'.format(CERTS_PATH)),
-    os.path.expanduser('{}client.key'.format(CERTS_PATH)))
+    CERTS_PATH = os.path.join(APT_ROOT, LXD_PATH)
+
+Cert = namedtuple('Cert', ['cert', 'key'])
+DEFAULT_CERTS = Cert(
+    cert=os.path.expanduser(os.path.join(CERTS_PATH, 'client.crt')),
+    key=os.path.expanduser(os.path.join(CERTS_PATH, 'client.key')))
 
 
 class _APINode(object):
@@ -216,8 +219,8 @@ class Client(object):
                 # Extra trailing slashes cause LXD to 301
                 endpoint = endpoint.rstrip('/')
                 if cert is None and (
-                        os.path.exists(DEFAULT_CERTS[0]) and
-                        os.path.exists(DEFAULT_CERTS[1])):
+                        os.path.exists(DEFAULT_CERTS.cert) and
+                        os.path.exists(DEFAULT_CERTS.key)):
                     cert = DEFAULT_CERTS
                 self.api = _APINode(
                     endpoint, cert=cert, verify=verify, timeout=timeout)

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -192,10 +192,15 @@ class Client(object):
             >>> print api.containers['test'].get().json()
 
     """
-
-    DEFAULT_CERTS = (
-        os.path.expanduser('~/.config/lxc/client.crt'),
-        os.path.expanduser('~/.config/lxc/client.key'))
+    if os.path.exists(
+            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.crt')):
+        DEFAULT_CERTS = (
+            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.crt'),
+            os.path.expanduser('~/snap/lxd/current/.config/lxc/client.key'))
+    else:
+        DEFAULT_CERTS = (
+            os.path.expanduser('~/.config/lxc/client.crt'),
+            os.path.expanduser('~/.config/lxc/client.key'))
 
     def __init__(
             self, endpoint=None, version='1.0', cert=None, verify=True,

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -210,6 +210,23 @@ class Client(object):
     def __init__(
             self, endpoint=None, version='1.0', cert=None, verify=True,
             timeout=None):
+        """Constructs a LXD client
+
+        :param endpoint: (optional): adnpoint can be an http endpoint or
+            a path to a unix socket.
+        :param version: (optional): API version string to use with LXD
+        :param cert: (optional): A tuple of (cert, key) to use with
+            the http socket for client authentication
+        :param verify: (optional): Either a boolean, in which case it controls
+            whether we verify the server's TLS certificate, or a string, in
+            which case it must be a path to a CA bundle to use.
+            Defaults to ``True``.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+
+        """
+
         self.cert = cert
         if endpoint is not None:
             if endpoint.startswith('/') and os.path.isfile(endpoint):

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -212,7 +212,7 @@ class Client(object):
             timeout=None):
         """Constructs a LXD client
 
-        :param endpoint: (optional): adnpoint can be an http endpoint or
+        :param endpoint: (optional): endpoint can be an http endpoint or
             a path to a unix socket.
         :param version: (optional): API version string to use with LXD
         :param cert: (optional): A tuple of (cert, key) to use with


### PR DESCRIPTION
When using a snap installed LXD, we need to look in the $HOME/snap
directory rather than looking in ~ for the certificates

Fixes #251