### PR TITLE
Add some doc links to the README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,3 +31,8 @@ We use the `LXC mailing-lists for developer and user discussions
 If you prefer live discussions, some of us also hang out in
 `#lxcontainers
 <http://webchat.freenode.net/?channels=#lxcontainers>`_ on irc.freenode.net.
+
+What is LXD? `LXD: Introduction <https://linuxcontainers.org/lxd/>`_
+
+PyLXD API Documentation: `http://pylxd.readthedocs.io/en/latest/
+<http://pylxd.readthedocs.io/en/latest/>`_


### PR DESCRIPTION
This is to allow the toplink on github to become the API link
rather than a link to the containers page.

Fixes #224