### PR TITLE
Update the containers documentation for 2.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+.eggs
 *.egg-info
 dist
 build

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -8,41 +8,57 @@ Client
 .. autoclass:: pylxd.client.Client
    :members:
 
+
+Exceptions
+----------
+
+.. autoclass:: pylxd.exceptions.LXDAPIException
+
+.. autoclass:: pylxd.exceptions.NotFound
+
+.. autoclass:: pylxd.exceptions.ClientConnectionFailed
+
 Certificate
 -----------
 
-.. autoclass:: pylxd.certificate.Certificate
+.. autoclass:: pylxd.models.Certificate
    :members:
 
 Container
 ---------
 
-.. autoclass:: pylxd.container.Container
+.. autoclass:: pylxd.models.Container
    :members:
 
-.. autoclass:: pylxd.container.Snapshot
+.. autoclass:: pylxd.models.Snapshot
    :members:
 
 Image
 -----
 
-.. autoclass:: pylxd.image.Image
+.. autoclass:: pylxd.models.Image
    :members:
 
 Network
 -------
 
-.. autoclass:: pylxd.network.Network
+.. autoclass:: pylxd.models.Network
    :members:
 
 Operation
 ---------
 
-.. autoclass:: pylxd.operation.Operation
+.. autoclass:: pylxd.models.Operation
    :members:
 
 Profile
 -------
 
-.. autoclass:: pylxd.profile.Profile
+.. autoclass:: pylxd.models.Profile
+   :members:
+
+Storage Pool
+------------
+
+.. autoclass:: pylxd.models.StoragePool
    :members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,7 +37,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pylxd'
-copyright = u'2016, Canonical Ltd'
+copyright = u'2016-2018, Canonical Ltd'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True

--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -13,9 +13,10 @@ Manager methods
 Containers can be queried through the following client manager
 methods:
 
+  - `exists(name)` - Returns `boolean` indicating if the container exists.
   - `all()` - Retrieve all containers.
   - `get()` - Get a specific container, by its name.
-  - `create(config, wait=False)` - Create a new container. This method 
+  - `create(config, wait=False)` - Create a new container. This method
     requires the container config as the first parameter.
     The config itself is beyond the scope of this documentation. Please
     refer to the LXD documentation for more information. This method
@@ -35,12 +36,14 @@ the LXD documentation.
   - `ephemeral` - Whether the container is ephemeral
   - `expanded_config` - An expanded version of the config
   - `expanded_devices` - An expanded version of devices
-  - `name` - The name of the container. This attribute serves as the
-    primary identifier of a container.
+  - `name` - (Read only) The name of the container. This attribute serves as the
+    primary identifier of a container
+  - `description` - A description given to the container
   - `profiles` - A list of profiles applied to the container
-  - `status` - A string representing the status of the container
-  - `status_code` - A LXD status code of the container
-  - `stateful` - Whether the container is stateful
+  - `status` - (Read only) A string representing the status of the container
+  - `last_used_at` - (Read only) when the container was last used
+  - `status_code` - (Read only) A LXD status code of the container
+  - `stateful` - (Read only) Whether the container is stateful
 
 
 Container methods
@@ -64,7 +67,8 @@ Container methods
   - `migrate` - Migrate the container. The first argument is a client
     connection to the destination server. This call is asynchronous, so
     `wait=True` is optional. The container on the new client is returned.
-
+  - `publish` - Publish the container as an image.  Note the container must be stopped
+    in order to use this method.  If `wait=True` is passed, then the image is returned.
 
 
 Examples
@@ -133,6 +137,14 @@ Snapshots are keyed by their name (and only their name, in pylxd; LXD
 keys them by <container-name>/<snapshot-name>, but the manager allows
 us to use our own namespacing).
 
+A container object (returned by `get` or `all`) has the following methods:
+
+  - `rename` - rename a snapshot
+  - `publish` - create an image from a snapshot.  However, this may fail if the
+    image from the snapshot is bigger than the logical volume that is allocated
+    by lxc.  See https://github.com/lxc/lxd/issues/2201 for more details.  The solution
+    is to increase the `storage.lvm_volume_size` parameter in lxc.
+
 .. code-block:: python
     >>> snapshot = container.snapshots.get('an-snapshot')
     >>> snapshot.created_at
@@ -143,7 +155,7 @@ us to use our own namespacing).
 
 To create a new snapshot, use `create` with a `name` argument. If you want
 to capture the contents of RAM in the snapshot, you can use `stateful=True`.
-**Note: Your LXD requires a relatively recent version of CRIU for this.**
+.. note:: Your LXD requires a relatively recent version of CRIU for this.
 
 .. code-block:: python
     >>> snapshot = container.snapshots.create(
@@ -156,7 +168,15 @@ Container files
 ---------------
 
 Containers also have a `files` manager for getting and putting files on the
-container.
+container.  The following methods are available on the `files` manager:
+
+  - `put` - push a file into the container.
+  - `get` - get a file from the container.
+  - `delete_available` - If the `file_delete` extension is available on the lxc
+    host, then this method returns `True` and the `delete` method is available.
+  - `delete` - delete a file on the container.
+
+.. note:: All file operations use `uid` and `gid` of 0 in the container.  i.e. root.
 
 .. code-block:: python
     >>> filedata = open('my-script').read()

--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -146,6 +146,7 @@ A container object (returned by `get` or `all`) has the following methods:
     is to increase the `storage.lvm_volume_size` parameter in lxc.
 
 .. code-block:: python
+
     >>> snapshot = container.snapshots.get('an-snapshot')
     >>> snapshot.created_at
     '1983-06-16T2:38:00'
@@ -158,6 +159,7 @@ to capture the contents of RAM in the snapshot, you can use `stateful=True`.
 .. note:: Your LXD requires a relatively recent version of CRIU for this.
 
 .. code-block:: python
+
     >>> snapshot = container.snapshots.create(
     ...     'my-backup', stateful=True, wait=True)
     >>> snapshot.name
@@ -179,6 +181,7 @@ container.  The following methods are available on the `files` manager:
 .. note:: All file operations use `uid` and `gid` of 0 in the container.  i.e. root.
 
 .. code-block:: python
+
     >>> filedata = open('my-script').read()
     >>> container.files.put('/tmp/my-script', filedata)
     >>> newfiledata = container.files.get('/tmp/my-script2')

--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -14,9 +14,10 @@ methods:
 
   - `all()` - Retrieve all images.
   - `get()` - Get a specific image, by its fingerprint.
+  - `get_by_alias()` - Ger a specific image using its alias.
 
-And create through the following methods,
-theres also a copy method on an image:
+And create through the following methods, there's also a copy method on an
+image:
 
   - `create(data, public=False, wait=False)` - Create a new image. The first
     argument is the binary data of the image itself. If the image is public,
@@ -48,7 +49,7 @@ the `LXD documentation`_.
   - `uploaded_at` - The date and time the image was uploaded
   - `update_source` - A dict of update informations
 
-.. _LXD documentation: https://github.com/lxc/lxd/blob/3207c2c67d02b3c7504c118f9af6262747103d65/doc/rest-api.md#10imagesfingerprint
+.. _LXD documentation: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10imagesfingerprint
 
 Image methods
 -------------
@@ -57,11 +58,8 @@ Image methods
     of the image. *Note: Prior to pylxd 2.1.1, this method returned a
     bytestring with data; as it was not unbuffered, the API was severely
     limited.*
-
   - `add_alias` - Add an alias to the image.
-
   - `delete_alias` - Remove an alias.
-
   - `copy` - Copy the image to another LXD client.
 
 Examples

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,7 +21,8 @@ Contents:
    images
    networks
    profiles
-
+   operations
+   storage-pools
 
    contributing
    api

--- a/doc/source/networks.rst
+++ b/doc/source/networks.rst
@@ -21,3 +21,5 @@ Network attributes
   - `name` - The name of the network
   - `type` - The type of the network
   - `used_by` - A list of containers using this network
+  - `config` - The configuration associated with the network.
+  - `managed` - Boolean; whether LXD manages the network

--- a/doc/source/networks.rst
+++ b/doc/source/networks.rst
@@ -16,7 +16,7 @@ methods:
 
 
 Network attributes
-----------------
+------------------
 
   - `name` - The name of the network
   - `type` - The type of the network

--- a/doc/source/operations.rst
+++ b/doc/source/operations.rst
@@ -1,0 +1,26 @@
+Operations
+========
+
+`Operation` objects detail the status of an asynchronous operation that is
+taking place in the background.  Some operations (e.g. image related actions)
+can take a long time and so the operation is performed in the background.  They
+return an operation `id` that may be used to discover the state of the
+operation.
+
+
+Manager methods
+---------------
+
+Operations can be queried through the following client manager methods:
+
+  - `get()` - Get a specific network, by its name.
+  - `wait_for_operation()` - get an operation, but wait until it is complete
+    before returning the operation object.
+
+
+Operation object methods
+------------------------
+
+  - `wait()` - Wait for the operation to complete and return.  Note that this
+    can raise a `LXDAPIExceptiion` if the operations fails.
+

--- a/doc/source/operations.rst
+++ b/doc/source/operations.rst
@@ -1,5 +1,5 @@
 Operations
-========
+==========
 
 `Operation` objects detail the status of an asynchronous operation that is
 taking place in the background.  Some operations (e.g. image related actions)

--- a/doc/source/profiles.rst
+++ b/doc/source/profiles.rst
@@ -11,6 +11,7 @@ Profiles can be queried through the following client manager
 methods:
 
   - `all()` - Retrieve all profiles
+  - `exists()` - See if a profile with a name exists.  Returns `boolean`.
   - `get()` - Get a specific profile, by its name.
   - `create(name, config, devices)` - Create a new profile. The name of the
     profile is required. `config` and `devices` dictionaries are optional,
@@ -31,6 +32,8 @@ Profile methods
 ---------------
 
   - `rename` - Rename the profile.
+  - `save` - save a profile.  This uses the PUT HTTP method and not the PATCH.
+  - `delete` - deletes a profile.
 
 
 Examples

--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -1,0 +1,44 @@
+Storage Pools
+=============
+
+LXD supports creating and managing storage pools and storage volumes. General
+keys are top-level. Driver specific keys are namespaced by driver name. Volume
+keys apply to any volume created in the pool unless the value is overridden on
+a per-volume basis.
+
+`Storage Pool` objects are represent the dictionary and associated methods that
+are returned from the API endpoint `GET /1.0/storage-pools/<name>`.
+
+Manager methods
+---------------
+
+Storage-pools can be queried through the following client manager methods:
+
+  - `all()` - Return a list of storage pools.
+  - `get()` - Get a specific storage-pool, by its name.
+  - `exists()` - Return a boolean for whether a storage-pool exists by name.
+  - `create()` - Create a storage-pool.  **Note the config in the create class
+    method is the WHOLE json object described as `input` in the API docs.**
+    e.g. the 'config' key in the API docs would actually be `config.config` as
+    passed to this method.
+
+
+Storage-pool attributes
+-----------------------
+
+For more information about the specifics of these attributes, please see
+the `LXD documentation`_.
+
+  - `name` - the name of the storage pool
+  - `driver` - the driver (or type of storage pool). e.g. 'zfs' or 'btrfs', etc.
+  - `used_by` - which containers (by API endpoint `/1.0/containers/<name>`) are
+    using this storage-pool.
+  - `config` - a string (json encoded) with some information about the
+    storage-pool.  e.g. size, source (path), volume.size, etc.
+
+.. _LXD documentation: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10storage-pools
+
+Storage-pool methods
+--------------------
+
+The are no storage pool methods defined yet.

--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -6,8 +6,9 @@ keys are top-level. Driver specific keys are namespaced by driver name. Volume
 keys apply to any volume created in the pool unless the value is overridden on
 a per-volume basis.
 
-`Storage Pool` objects are represent the dictionary and associated methods that
-are returned from the API endpoint `GET /1.0/storage-pools/<name>`.
+`Storage Pool` objects represent the json object that is return from
+`GET /1.0/storage-pools/<name>` and then the associated methods that are then
+available at the same endpoint.
 
 Manager methods
 ---------------

--- a/doc/source/storage-pools.rst
+++ b/doc/source/storage-pools.rst
@@ -6,7 +6,7 @@ keys are top-level. Driver specific keys are namespaced by driver name. Volume
 keys apply to any volume created in the pool unless the value is overridden on
 a per-volume basis.
 
-`Storage Pool` objects represent the json object that is return from
+`Storage Pool` objects represent the json object that is returned from
 `GET /1.0/storage-pools/<name>` and then the associated methods that are then
 available at the same endpoint.
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -39,6 +39,7 @@ itself. This includes `certificates`, `containers`, `images`, `networks`,
 LXD instance. For example, to get all containers in a LXD instance
 
 .. code-block:: python
+
     >>> client.containers.all()
     [<container.Container at 0x7f95d8af72b0>,]
 
@@ -54,6 +55,7 @@ Each LXD object has an analagous pylxd object. Returning to the previous
 such:
 
 .. code-block:: python
+
     >>> container = client.containers.all()[0]
     >>> container.name
     'lxd-container'
@@ -77,6 +79,7 @@ methods and attributes:
 Returning again to the `Container` example
 
 .. code-block:: python
+
     >>> container.config
     { 'security.privileged': True }
     >>> container.config.update({'security.nesting': True})


### PR DESCRIPTION
Update the documentation to match the current functionality offered by the library.
Fixes to docs to remove warnings/errors from sphinx autodoc class documentation generation.
Additions of several pages to cover new functionality.

Closes #260 
Closes #263 