### PR TITLE
Fix bug #232 for 2.0 series branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - test -d .tox/$TOXENV/log && cat .tox/$TOXENV/log/*.log || true
 cache:
   directories:
-    - .tox/$TOXENV
     - $HOME/.cache/pip
 after_success:
   - codecov

--- a/pylxd/model.py
+++ b/pylxd/model.py
@@ -19,6 +19,9 @@ from pylxd.deprecation import deprecated
 from pylxd.operation import Operation
 
 
+MISSING = object()
+
+
 class Attribute(object):
     """A metadata class for model attributes."""
 
@@ -149,9 +152,23 @@ class Model(object):
         # XXX: rockstar (25 Jun 2016) - This has the potential to step
         # on existing attributes.
         response = self.api.get()
-        for key, val in response.json()['metadata'].items():
+        payload = response.json()['metadata']
+        for key, val in payload.items():
             if key not in self.__dirty__ or rollback:
-                setattr(self, key, val)
+                try:
+                    setattr(self, key, val)
+                    self.__dirty__.remove(key)
+                except AttributeError:
+                    # We have received an attribute from the server that we
+                    # don't support in our model. Ignore this error, it
+                    # doesn't hurt us.
+                    pass
+
+        # Make sure that *all* supported attributes are set, even those that
+        # aren't supported by the server.
+        missing_attrs = set(self.__attributes__.keys()) - set(payload.keys())
+        for missing_attr in missing_attrs:
+            setattr(self, missing_attr, MISSING)
         if rollback:
             del self.__dirty__[:]
     fetch = deprecated("fetch is deprecated; please use sync")(sync)
@@ -188,8 +205,12 @@ class Model(object):
     def marshall(self):
         """Marshall the object in preparation for updating to the server."""
         marshalled = {}
-        for key, val in self.__attributes__.items():
-            if ((not val.readonly and not val.optional) or
-                    (val.optional and hasattr(self, key))):
-                marshalled[key] = getattr(self, key)
+        for key, attr in self.__attributes__.items():
+            if ((not attr.readonly and not attr.optional) or
+                    (attr.optional and hasattr(self, key))):
+                val = getattr(self, key)
+                # Don't send back to the server an attribute it doesn't
+                # support.
+                if val is not MISSING:
+                    marshalled[key] = val
         return marshalled

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -185,6 +185,7 @@ RULES = [
                 },
                 'created_at': "1983-06-16T00:00:00-00:00",
                 'last_used_at': "1983-06-16T00:00:00-00:00",
+                'description': "Some description",
                 'devices': {
                     'root': {
                         'path': "/",

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -213,7 +213,8 @@ RULES = [
                 ],
                 'stateful': False,
                 'status': "Running",
-                'status_code': 103
+                'status_code': 103,
+                'unsupportedbypylxd': "This attribute is not supported by pylxd. We want to test whether the mere presence of it makes it crash."
             }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -214,7 +214,9 @@ RULES = [
                 'stateful': False,
                 'status': "Running",
                 'status_code': 103,
-                'unsupportedbypylxd': "This attribute is not supported by pylxd. We want to test whether the mere presence of it makes it crash."
+                'unsupportedbypylxd': ("This attribute is not supported by "
+                                       "pylxd. We want to test whether the "
+                                       "mere presence of it makes it crash.")
             }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
 requests!=2.8.0,>=2.5.2
 requests-unixsocket>=0.1.5
 cryptography>=1.4
+pyOpenSSL>=0.14;python_version<='2.7.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.0.5
+version = 2.0.6
 description-file =
     README.rst
 author = Paul Hummer

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,7 @@ nose>=1.3.7
 mock>=1.3.0
 flake8>=2.5.0
 coverage>=4.1
-# See https://github.com/novafloss/mock-services/pull/15
--e git://github.com/rockstar/mock-services.git@aba3977d1a3f43afd77d99f241ee1111c20deeed#egg=mock-services
+mock-services>=0.3
+# mock-services is old and unmaintained. Doesn't work with newer versions of
+# requests-mock. Thus, we have to pin it down.
+requests-mock<1.2


### PR DESCRIPTION
Bug #232 ('Container' object has no attribute 'description') breaks v2.0.5 packaged in Ubuntu Xenial 16.04 LTS as a backport to lxd 2.0.11 grew a new attribute called 'description' on the container JSON returned from lxd.  This breaks v2.0.5.  v.2.24 of pylxd grew the ability to ignore attributes it didn't know about and thus work with lxd 2.0.11.