### PR TITLE
Fix branch-2.0 integration tests

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -71,7 +71,7 @@ class TestContainer(IntegrationTestCase):
     def test_update(self):
         """The container is updated to a new config."""
         self.container.config['limits.cpu'] = '1'
-        self.container.update(wait=True)
+        self.container.save(wait=True)
 
         self.assertEqual('1', self.container.config['limits.cpu'])
         container = self.client.containers.get(self.container.name)
@@ -90,9 +90,8 @@ class TestContainer(IntegrationTestCase):
         """The container is deleted."""
         self.container.delete(wait=True)
 
-        self.assertRaises(
-            exceptions.NotFound,
-            self.client.containers.get, self.container.name)
+        with self.assertRaises(exceptions.LXDAPIException):
+            self.client.containers.get(self.container.name)
 
     def test_start_stop(self):
         """The container is started and then stopped."""

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -71,7 +71,7 @@ class TestImage(IntegrationTestCase):
         """The image properties are updated."""
         description = 'an description'
         self.image.properties['description'] = description
-        self.image.update()
+        self.image.save()
 
         image = self.client.images.get(self.image.fingerprint)
         self.assertEqual(description, image.properties['description'])
@@ -80,9 +80,8 @@ class TestImage(IntegrationTestCase):
         """The image is deleted."""
         self.image.delete(wait=True)
 
-        self.assertRaises(
-            exceptions.NotFound,
-            self.client.images.get, self.image.fingerprint)
+        with self.assertRaises(exceptions.LXDAPIException):
+            self.client.images.get(self.image.fingerprint)
 
     def test_export(self):
         """The imerage is successfully exported."""

--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -65,7 +65,7 @@ class TestProfile(IntegrationTestCase):
     def test_update(self):
         """A profile is updated."""
         self.profile.config['limits.memory'] = '16GB'
-        self.profile.update()
+        self.profile.save()
 
         profile = self.client.profiles.get(self.profile.name)
         self.assertEqual('16GB', profile.config['limits.memory'])
@@ -85,5 +85,5 @@ class TestProfile(IntegrationTestCase):
         """A profile is deleted."""
         self.profile.delete()
 
-        self.assertRaises(
-            exceptions.NotFound, self.client.profiles.get, self.profile.name)
+        with self.assertRaises(exceptions.LXDAPIException):
+            self.client.profiles.get(self.profile.name)

--- a/run_integration_tests
+++ b/run_integration_tests
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+CONTAINER_IMAGE=ubuntu:16.04
+CONTAINER_NAME=pylxd-`uuidgen | cut -d"-" -f1`
+
+# This creates a privileged container, because I was bumping into situations where it
+# seemed that we had maxed out user namespaces (I haven't checked it out, but it's likely
+# a bug in LXD).
+lxc launch $CONTAINER_IMAGE $CONTAINER_NAME -c security.nesting=true -c security.privileged=true
+sleep 5  # Wait for the network to come up
+lxc exec $CONTAINER_NAME -- apt-get update
+lxc exec $CONTAINER_NAME -- apt-get install -y tox python3-dev libssl-dev libffi-dev build-essential
+
+lxc exec $CONTAINER_NAME -- lxc config set core.trust_password password
+lxc exec $CONTAINER_NAME -- lxc config set core.https_address [::]
+
+lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
+# NOTE: rockstar (13 Sep 2016) - --recursive is not supported in lxd <2.1, so
+# until we have pervasive support for that, we'll do this tar hack.
+tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
+lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
+lxc delete --force $CONTAINER_NAME

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.0.7
+version = 2.0.8
 description-file =
     README.rst
 author = Paul Hummer


### PR DESCRIPTION
The integration tests in the integrations/ sub-folder has bit-rotted.
This patch brings them up to date so that they work with the branch-2.0
current.  This is for SRU testing for xenial, which the branch-2.0
tracks releases for.

Signed-off-by: Alex Kavanagh <alex@ajkavanagh.co.uk>