### PR TITLE
Add back profile rename integration test

### DIFF
--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -70,7 +70,6 @@ class TestProfile(IntegrationTestCase):
         profile = self.client.profiles.get(self.profile.name)
         self.assertEqual('16GB', profile.config['limits.memory'])
 
-    @unittest.skip('Not implemented in LXD')
     def test_rename(self):
         """A profile is renamed."""
         name = 'a-other-profile'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.6
+version = 2.2.7
 description-file =
     README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)


### PR DESCRIPTION
Add back in the skipped profile rename test on the integration test suite and bump the version to make pbr happy when running those tests.