### PR TITLE
Bug/280/long running container

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include AUTHORS
 include ChangeLog
 exclude .gitignore
 exclude .gitreview
+exclude contrib_testing
 
 global-exclude *.pyc

--- a/contrib_testing/README.md
+++ b/contrib_testing/README.md
@@ -1,0 +1,5 @@
+# Contrib Testing
+
+The files in this directory help to test some obscure parts of the execute
+command on containers.  They should be integrated into the test suite, but it's
+tricky to do that programmatically.

--- a/contrib_testing/local-http-test.py
+++ b/contrib_testing/local-http-test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import datetime
+import pylxd
+import requests
+import time
+
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+def log(s):
+    now = datetime.datetime.utcnow()
+    print("{} - {}".format(now, s))
+
+
+def create_and_update(client):
+    log("Creating...")
+    base = client.containers.create({
+        'name': 'ubuntu-1604',
+        'source': {
+            'type': 'image',
+            'protocol': 'simplestreams',
+            'server': 'https://images.linuxcontainers.org',
+            'alias': 'ubuntu/xenial/amd64'
+        }
+    }, wait=True)
+    log("starting...")
+    base.start(wait=True)
+    while len(base.state().network['eth0']['addresses']) < 2:
+        time.sleep(1)
+    commands = [
+        ['apt-get', 'update'],
+        ['apt-get', 'install', 'openssh-server', 'sudo', 'man', '-y']
+    ]
+    for command in commands:
+        log("command: {}".format(command))
+        result = base.execute(command)
+        log("result: {}".format(result.exit_code))
+        log("stdout: {}".format(result.stdout))
+        log("stderr: {}".format(result.stderr))
+
+
+if __name__ == '__main__':
+    client = pylxd.Client("https://127.0.0.1:8443/", verify=False)
+    log("Authenticating...")
+    client.authenticate('password')
+
+    create_and_update(client)

--- a/contrib_testing/local-unix-test.py
+++ b/contrib_testing/local-unix-test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import datetime
+import pylxd
+import requests
+import time
+
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+def log(s):
+    now = datetime.datetime.utcnow()
+    print("{} - {}".format(now, s))
+
+
+def create_and_update(client):
+    log("Creating...")
+    base = client.containers.create({
+        'name': 'ubuntu-1604',
+        'source': {
+            'type': 'image',
+            'protocol': 'simplestreams',
+            'server': 'https://images.linuxcontainers.org',
+            'alias': 'ubuntu/xenial/amd64'
+        }
+    }, wait=True)
+    log("starting...")
+    base.start(wait=True)
+    while len(base.state().network['eth0']['addresses']) < 2:
+        time.sleep(1)
+    commands = [
+        ['apt-get', 'update'],
+        ['apt-get', 'install', 'openssh-server', 'sudo', 'man', '-y']
+    ]
+    for command in commands:
+        log("command: {}".format(command))
+        result = base.execute(command)
+        log("result: {}".format(result.exit_code))
+        log("stdout: {}".format(result.stdout))
+        log("stderr: {}".format(result.stderr))
+
+
+if __name__ == '__main__':
+    client = pylxd.Client()
+    log("Authenticating...")
+    client.authenticate('password')
+
+    create_and_update(client)

--- a/contrib_testing/remote-test.py
+++ b/contrib_testing/remote-test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import datetime
+import pylxd
+import requests
+import time
+
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+
+def log(s):
+    now = datetime.datetime.utcnow()
+    print("{} - {}".format(now, s))
+
+
+def create_and_update(client):
+    log("Creating...")
+    base = client.containers.create({
+        'name': 'ubuntu-1604',
+        'source': {
+            'type': 'image',
+            'protocol': 'simplestreams',
+            'server': 'https://images.linuxcontainers.org',
+            'alias': 'ubuntu/xenial/amd64'
+        }
+    }, wait=True)
+    log("starting...")
+    base.start(wait=True)
+    while len(base.state().network['eth0']['addresses']) < 2:
+        time.sleep(1)
+    commands = [
+        ['sleep', '10'],
+        ['apt-get', 'update'],
+        ['apt-get', 'install', 'openssh-server', 'sudo', 'man', '-y']
+    ]
+    for command in commands:
+        log("command: {}".format(command))
+        result = base.execute(command)
+        log("result: {}".format(result.exit_code))
+        log("stdout: {}".format(result.stdout))
+        log("stderr: {}".format(result.stderr))
+
+
+if __name__ == '__main__':
+    client = pylxd.Client("https://10.245.162.33:8443/", verify=False)
+    log("Authenticating...")
+    client.authenticate('password')
+
+    create_and_update(client)

--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -11,8 +11,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import unittest
-
 from pylxd import exceptions
 
 from integration.testing import IntegrationTestCase

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -293,10 +293,20 @@ class Container(model.Model):
 
             manager.start()
 
+            # watch for the end of the command:
+            while True:
+                operation = self.client.operations.get(operation_id)
+                if 'return' in operation.metadata:
+                    break
+                time.sleep(.5)
+
             while len(manager.websockets.values()) > 0:
                 time.sleep(.1)
 
-            operation = self.client.operations.get(operation_id)
+            stdout.close()
+            stderr.close()
+            manager.stop()
+            manager.join()
 
             return _ContainerExecuteResult(
                 operation.metadata['return'], stdout.data, stderr.data)
@@ -382,9 +392,6 @@ class _CommandWebsocketClient(WebSocketBaseClient):  # pragma: no cover
         self.buffer = []
 
     def received_message(self, message):
-        if len(message.data) == 0:
-            self.close()
-            self.manager.remove(self)
         if message.encoding:
             self.buffer.append(message.data.decode(message.encoding))
         else:

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -298,10 +298,10 @@ class Container(model.Model):
                 operation = self.client.operations.get(operation_id)
                 if 'return' in operation.metadata:
                     break
-                time.sleep(.5)
+                time.sleep(.5)  # pragma: no cover
 
             while len(manager.websockets.values()) > 0:
-                time.sleep(.1)
+                time.sleep(.1)  # pragma: no cover
 
             stdout.close()
             stderr.close()


### PR DESCRIPTION
The bug presented as the operation not still existing at the lxd
daemon when the end of the command was reached.  After much testing,
it seemed that the pylxd client was closing the websockets when the
empty message was received on them, which turned out to be too late
for some kinds of output.  Instead, tracking when the operation
completed, and then waiting for the sockets to close meant that the
return code of the command could be obtained, and the wait for the
sockets to be closed by the lxd daemon ensured completion.  The code
also waits for the ws4py manager to clean up and waits on the threads to
end.  This helps with multiple commands.