### PR TITLE
Fix bug/281 unable to get file with json content

### DIFF
--- a/integration/test_profiles.py
+++ b/integration/test_profiles.py
@@ -11,8 +11,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import unittest
-
 from pylxd import exceptions
 
 from integration.testing import IntegrationTestCase

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -138,7 +138,7 @@ class Container(model.Model):
 
         def get(self, filepath):
             response = (self._client.api.containers[self._container.name]
-                        .files.get(params={'path': filepath}))
+                        .files.get(params={'path': filepath}, is_api=False))
             return response.content
 
     @classmethod

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -354,6 +354,11 @@ RULES = [
         'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fgetted$',  # NOQA
     },
     {
+        'text': '{"some": "value"}',
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fjson-get$',  # NOQA
+    },
+    {
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/files\?path=%2Ftmp%2Fputted$',  # NOQA
     },

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -551,3 +551,9 @@ class TestFiles(testing.PyLXDTestCase):
         self.assertRaises(
             exceptions.LXDAPIException,
             self.container.files.get, '/tmp/getted')
+
+    # for bug/281 -- getting an empty json file is interpreted as an API
+    # get rather than a raw get.
+    def test_get_json_file(self):
+        data = self.container.files.get('/tmp/json-get')
+        self.assertEqual(b'{"some": "value"}', data)


### PR DESCRIPTION
The issue was that the files handling uses the API get code path to
fetch files.  Thus json files were intepreted as an API reponse and
checked for content.  This change ensures that the contents of files are
returned without trying to interpret the contents.

Signed-off-by: Alex Kavanagh <alex@ajkavanagh.co.uk>