### PR TITLE
Enable decoding control over stdout/stderr on execute

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -155,6 +155,30 @@ class TestContainer(IntegrationTestCase):
         self.assertEqual('test\n', result.stdout)
         self.assertEqual('', result.stderr)
 
+    def test_execute_no_decode(self):
+        """A command is executed on the container that isn't utf-8 decodable
+        """
+        self.container.start(wait=True)
+        self.addCleanup(self.container.stop, wait=True)
+
+        result = self.container.execute(['printf', '\\xff'], decode=None)
+
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(b'\xff', result.stdout)
+        self.assertEqual(b'', result.stderr)
+
+    def test_execute_force_decode(self):
+        """A command is executed and force output to ascii"""
+        self.container.start(wait=True)
+        self.addCleanup(self.container.stop, wait=True)
+
+        result = self.container.execute(['printf', 'qu\\xe9'], decode=True,
+                                        encoding='latin1')
+
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual('qué', result.stdout)
+        self.assertEqual('', result.stderr)
+
     def test_publish(self):
         """A container is published."""
         image = self.container.publish(wait=True)


### PR DESCRIPTION
This patch adds support to control the decoding of the stdout
and stderr when executing commands in a container.  It is possible to
force a particular decode, or just get the raw buffers.  The existing
behaviour of trying to decode to utf-8 is retained if no decode or
encoding paramters are passed to the execute method.

Tests are in the integration/test_containers.py file as it's tricky to
test properly in a unit test.

Signed-off-by: Alex Kavanagh <alex@ajkavanagh.co.uk>