### PR TITLE
Add network operations

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -32,5 +32,6 @@ These are the contributors to pylxd according to the Github repository.
  Synforge         Paul Oyston
  overquota        ???
  chrismacnaughton Chris MacNaughton
+ ppkt             Karol Werner
  ===============  ==================================
 

--- a/doc/source/networks.rst
+++ b/doc/source/networks.rst
@@ -1,7 +1,11 @@
+.. py:currentmodule:: pylxd.models
+
 Networks
 ========
 
-`Network` objects show the current networks available to lxd.
+:class:`Network` objects show the current networks available to LXD. Creation
+and / or modification of networks is possible only if 'network' LXD API
+extension is present (see :func:`~Network.network_extension_available`)
 
 
 Manager methods
@@ -10,11 +14,13 @@ Manager methods
 Networks can be queried through the following client manager
 methods:
 
-  - `all()` - Retrieve all networks.
-  - `exists()` - See if a profile with a name exists.  Returns `boolean`.
-  - `get()` - Get a specific network, by its name.
-  - `create(name, description, type_, config)` - Create a new network.
-    The name of the network is required. `description`, `type_` and `config`
+
+  - :func:`~Network.all` - Retrieve all networks.
+  - :func:`~Network.exists` - See if a profile with a name exists.
+    Returns `bool`.
+  - :func:`~Network.get` - Get a specific network, by its name.
+  - :func:`~Network.create` - Create a new network.
+    The name of the network is required. `description`, `type` and `config`
     are optional and the scope of their contents is documented in the LXD
     documentation.
 
@@ -22,32 +28,51 @@ methods:
 Network attributes
 ------------------
 
-  - `name` - The name of the network.
-  - `description` - The description of the network.
-  - `type` - The type of the network.
-  - `used_by` - A list of containers using this network.
-  - `config` - The configuration associated with the network.
-  - `managed` - `boolean`; whether LXD manages the network.
+  - :attr:`~Network.name` - The name of the network.
+  - :attr:`~Network.description` - The description of the network.
+  - :attr:`~Network.type` - The type of the network.
+  - :attr:`~Network.used_by` - A list of containers using this network.
+  - :attr:`~Network.config` - The configuration associated with the network.
+  - :attr:`~Network.managed` - `boolean`; whether LXD manages the network.
 
 
 Profile methods
 ---------------
 
-  - `rename` - Rename the network.
-  - `save` - Save the network. This uses the PUT HTTP method and not the PATCH.
-  - `delete` - Deletes the network.
+  - :func:`~Network.rename` - Rename the network.
+  - :func:`~Network.save` - Save the network. This uses the PUT HTTP method and
+    not the PATCH.
+  - :func:`~Network.delete` - Deletes the network.
+
+.. py:currentmodule:: pylxd.models
 
 Examples
 --------
 
-:class:`~network.Network` operations follow the same manager-style as other
-classes. Network are keyed on a unique name.
+:class:`Network` operations follow the same manager-style as other
+classes. Networks are keyed on a unique name.
 
 .. code-block:: python
 
     >>> network = client.networks.get('lxdbr0')
+
     >>> network
-    <pylxd.models.network.Network object at 0x7f66ae4a2840>
+    Network(config={"ipv4.address": "10.74.126.1/24", "ipv4.nat": "true", "ipv6.address": "none"}, description="", name="lxdbr0", type="bridge")
+
+    >>> print(network)
+    {
+      "name": "lxdbr0",
+      "description": "",
+      "type": "bridge",
+      "config": {
+        "ipv4.address": "10.74.126.1/24",
+        "ipv4.nat": "true",
+        "ipv6.address": "none"
+      },
+      "managed": true,
+      "used_by": []
+    }
+
 
 
 The network can then be modified and saved.
@@ -56,8 +81,16 @@ The network can then be modified and saved.
     >>> network.save()
 
 
-To create a new network, use `create` with a name, and optional arguments:
-`description` and `type_` and `config`.
+To create a new network, use :func:`~Network.create` with a name, and optional
+arguments: `description` and `type` and `config`.
 
     >>> network = client.networks.create(
-    ...     'lxdbr1', description='My new network', type_='bridge', config={})
+    ...     'lxdbr1', description='My new network', type='bridge', config={})
+
+
+    >>> network = client.networks.create(
+    ...     'lxdbr1', description='My new network', type='bridge', config={})
+
+
+    >>> network = client.networks.create(
+    ...     'lxdbr1', description='My new network', type='bridge', config={})

--- a/doc/source/networks.rst
+++ b/doc/source/networks.rst
@@ -1,8 +1,7 @@
 Networks
 ========
 
-`Network` objects show the current networks available to lxd. They are
-read-only via the REST API.
+`Network` objects show the current networks available to lxd.
 
 
 Manager methods
@@ -11,15 +10,54 @@ Manager methods
 Networks can be queried through the following client manager
 methods:
 
-  - `all()` - Retrieve all networks
+  - `all()` - Retrieve all networks.
+  - `exists()` - See if a profile with a name exists.  Returns `boolean`.
   - `get()` - Get a specific network, by its name.
+  - `create(name, description, type_, config)` - Create a new network.
+    The name of the network is required. `description`, `type_` and `config`
+    are optional and the scope of their contents is documented in the LXD
+    documentation.
 
 
 Network attributes
 ------------------
 
-  - `name` - The name of the network
-  - `type` - The type of the network
-  - `used_by` - A list of containers using this network
+  - `name` - The name of the network.
+  - `description` - The description of the network.
+  - `type` - The type of the network.
+  - `used_by` - A list of containers using this network.
   - `config` - The configuration associated with the network.
-  - `managed` - Boolean; whether LXD manages the network
+  - `managed` - `boolean`; whether LXD manages the network.
+
+
+Profile methods
+---------------
+
+  - `rename` - Rename the network.
+  - `save` - Save the network. This uses the PUT HTTP method and not the PATCH.
+  - `delete` - Deletes the network.
+
+Examples
+--------
+
+:class:`~network.Network` operations follow the same manager-style as other
+classes. Network are keyed on a unique name.
+
+.. code-block:: python
+
+    >>> network = client.networks.get('lxdbr0')
+    >>> network
+    <pylxd.models.network.Network object at 0x7f66ae4a2840>
+
+
+The network can then be modified and saved.
+
+    >>> network.config['ipv4.address'] = '10.253.10.1/24'
+    >>> network.save()
+
+
+To create a new network, use `create` with a name, and optional arguments:
+`description` and `type_` and `config`.
+
+    >>> network = client.networks.create(
+    ...     'lxdbr1', description='My new network', type_='bridge', config={})

--- a/integration/test_networks.py
+++ b/integration/test_networks.py
@@ -11,11 +11,22 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 from integration.testing import IntegrationTestCase
 from pylxd import exceptions
+from pylxd.models import Network
 
 
-class TestNetworks(IntegrationTestCase):
+class NetworkTestCase(IntegrationTestCase):
+
+    def setUp(self):
+        super(NetworkTestCase, self).setUp()
+
+        if not Network.network_extension_available(self.client):
+            self.skipTest('Required LXD API extension not available!')
+
+
+class TestNetworks(NetworkTestCase):
     """Tests for `Client.networks.`"""
 
     def test_get(self):
@@ -58,7 +69,7 @@ class TestNetworks(IntegrationTestCase):
                 'ipv6.address': 'none',
                 'ipv6.nat': 'false',
             },
-            'type_': 'bridge',
+            'type': 'bridge',
             'description': 'network description',
         }
 
@@ -67,12 +78,12 @@ class TestNetworks(IntegrationTestCase):
 
         self.assertEqual(kwargs['name'], network.name)
         self.assertEqual(kwargs['config'], network.config)
-        self.assertEqual(kwargs['type_'], network.type)
+        self.assertEqual(kwargs['type'], network.type)
         self.assertTrue(network.managed)
         self.assertEqual(kwargs['description'], network.description)
 
 
-class TestNetwork(IntegrationTestCase):
+class TestNetwork(NetworkTestCase):
     """Tests for `Network`."""
 
     def setUp(self):

--- a/integration/test_networks.py
+++ b/integration/test_networks.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2016 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from integration.testing import IntegrationTestCase
+from pylxd import exceptions
+
+
+class TestNetworks(IntegrationTestCase):
+    """Tests for `Client.networks.`"""
+
+    def test_get(self):
+        """A network is fetched by its name."""
+        name = self.create_network()
+
+        self.addCleanup(self.delete_network, name)
+        network = self.client.networks.get(name)
+
+        self.assertEqual(name, network.name)
+
+    def test_all(self):
+        """All networks are fetched."""
+        name = self.create_network()
+
+        self.addCleanup(self.delete_network, name)
+
+        networks = self.client.networks.all()
+
+        self.assertIn(name, [network.name for network in networks])
+
+    def test_create_default_arguments(self):
+        """A network is created with default arguments"""
+        name = 'eth10'
+        network = self.client.networks.create(name=name)
+        self.addCleanup(self.delete_network, name)
+
+        self.assertEqual(name, network.name)
+        self.assertTrue(network.managed)
+        self.assertEqual('bridge', network.type)
+        self.assertEqual('', network.description)
+
+    def test_create_with_parameters(self):
+        """A network is created with provided arguments"""
+        kwargs = {
+            'name': 'eth10',
+            'config': {
+                'ipv4.address': '10.10.10.1/24',
+                'ipv4.nat': 'true',
+                'ipv6.address': 'none',
+                'ipv6.nat': 'false',
+            },
+            'type_': 'bridge',
+            'description': 'network description',
+        }
+
+        network = self.client.networks.create(**kwargs)
+        self.addCleanup(self.delete_network, kwargs['name'])
+
+        self.assertEqual(kwargs['name'], network.name)
+        self.assertEqual(kwargs['config'], network.config)
+        self.assertEqual(kwargs['type_'], network.type)
+        self.assertTrue(network.managed)
+        self.assertEqual(kwargs['description'], network.description)
+
+
+class TestNetwork(IntegrationTestCase):
+    """Tests for `Network`."""
+
+    def setUp(self):
+        super(TestNetwork, self).setUp()
+        name = self.create_network()
+        self.network = self.client.networks.get(name)
+
+    def tearDown(self):
+        super(TestNetwork, self).tearDown()
+        self.delete_network(self.network.name)
+
+    def test_save(self):
+        """A network is updated"""
+        self.network.config['ipv4.address'] = '11.11.11.1/24'
+        self.network.save()
+
+        network = self.client.networks.get(self.network.name)
+        self.assertEqual('11.11.11.1/24', network.config['ipv4.address'])
+
+    def test_rename(self):
+        """A network is renamed"""
+        name = 'eth20'
+        self.addCleanup(self.delete_network, name)
+
+        self.network.rename(name)
+        network = self.client.networks.get(name)
+
+        self.assertEqual(name, network.name)
+
+    def test_delete(self):
+        """A network is deleted"""
+        self.network.delete()
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            self.client.networks.get, self.network.name)

--- a/integration/testing.py
+++ b/integration/testing.py
@@ -11,12 +11,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import random
+import string
 import unittest
 import uuid
 
+from integration.busybox import create_busybox_image
 from pylxd import exceptions
 from pylxd.client import Client
-from integration.busybox import create_busybox_image
 
 
 class IntegrationTestCase(unittest.TestCase):
@@ -128,6 +130,21 @@ class IntegrationTestCase(unittest.TestCase):
             if e.response.status_code == 404:
                 return
             raise
+
+    def create_network(self):
+        # get interface name in format xxx0
+        name = ''.join(random.sample(string.ascii_lowercase, 3)) + '0'
+        self.lxd.networks.post(json={
+            'name': name,
+            'config': {},
+        })
+        return name
+
+    def delete_network(self, name):
+        try:
+            self.lxd.networks[name].delete()
+        except exceptions.NotFound:
+            pass
 
     def assertCommon(self, response):
         """Assert common LXD responses.

--- a/pylxd/exceptions.py
+++ b/pylxd/exceptions.py
@@ -30,5 +30,10 @@ class NotFound(LXDAPIException):
     """An exception raised when an object is not found."""
 
 
+class LXDAPIExtensionNotAvailable(Exception):
+    """An exception raised when requested LXD API Extension is not present
+    on current host."""
+
+
 class ClientConnectionFailed(Exception):
     """An exception raised when the Client connection fails."""

--- a/pylxd/models/_model.py
+++ b/pylxd/models/_model.py
@@ -200,12 +200,14 @@ class Model(object):
                 response.json()['operation'])
         self.client = None
 
-    def marshall(self):
+    def marshall(self, skip_readonly=True):
         """Marshall the object in preparation for updating to the server."""
         marshalled = {}
         for key, attr in self.__attributes__.items():
-            if ((not attr.readonly and not attr.optional) or
-                    (attr.optional and hasattr(self, key))):
+            if attr.readonly and skip_readonly:
+                continue
+            if (not attr.optional) or (  # pragma: no branch
+                    attr.optional and hasattr(self, key)):
                 val = getattr(self, key)
                 # Don't send back to the server an attribute it doesn't
                 # support.

--- a/pylxd/models/network.py
+++ b/pylxd/models/network.py
@@ -17,18 +17,27 @@ from pylxd.models import _model as model
 class Network(model.Model):
     """A LXD network."""
     name = model.Attribute()
+    description = model.Attribute()
     type = model.Attribute()
-    used_by = model.Attribute()
     config = model.Attribute()
-    managed = model.Attribute()
+    managed = model.Attribute(readonly=True)
+    used_by = model.Attribute(readonly=True)
+
+    @classmethod
+    def exists(cls, client, name):
+        """Determine whether a network exists."""
+        try:
+            client.networks.get(name)
+            return True
+        except cls.NotFound:
+            return False
 
     @classmethod
     def get(cls, client, name):
         """Get a network by name."""
         response = client.api.networks[name].get()
 
-        network = cls(client, **response.json()['metadata'])
-        return network
+        return cls(client, **response.json()['metadata'])
 
     @classmethod
     def all(cls, client):
@@ -41,14 +50,25 @@ class Network(model.Model):
             networks.append(cls(client, name=name))
         return networks
 
+    @classmethod
+    def create(cls, client, name, description=None, type_=None,
+               config=None):
+        """Create a network"""
+        network = {'name': name}
+        if description is not None:
+            network['description'] = description
+        if type_ is not None:
+            network['type'] = type_
+        if config is not None:
+            network['config'] = config
+        client.api.networks.post(json=network)
+        return cls.get(client, name)
+
+    def rename(self, new_name):
+        """Rename network."""
+        self.client.api.networks.post(json={'name': new_name})
+        return Network.get(self.client, new_name)
+
     @property
     def api(self):
         return self.client.api.networks[self.name]
-
-    def save(self, wait=False):
-        """Save is not available for networks."""
-        raise NotImplementedError('save is not implemented')
-
-    def delete(self):
-        """Delete is not available for networks."""
-        raise NotImplementedError('delete is not implemented')

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -49,6 +49,54 @@ def image_DELETE(request, context):
         'operation': 'operation-abc'})
 
 
+def networks_GET(request, _):
+    name = request.path.split('/')[-1]
+    return json.dumps({
+        'type': 'sync',
+        'metadata': {
+            'config': {
+                'ipv4.address': '10.80.100.1/24',
+                'ipv4.nat': 'true',
+                'ipv6.address': 'none',
+                'ipv6.nat': 'false',
+            },
+            'name': name,
+            'description': 'Network description',
+            'type': 'bridge',
+            'managed': True,
+            'used_by': [],
+        },
+    })
+
+
+def networks_POST(_, context):
+    context.status_code = 200
+    return json.dumps({
+        'type': 'sync',
+        'metadata': {}})
+
+
+def networks_DELETE(_, context):
+    context.status_code = 202
+    return json.dumps({
+        'type': 'sync',
+        'operation': 'operation-abc'})
+
+
+def profile_GET(request, context):
+    name = request.path.split('/')[-1]
+    return json.dumps({
+        'type': 'sync',
+        'metadata': {
+            'name': name,
+            'description': 'An description',
+            'config': {},
+            'devices': {},
+            'used_by': [],
+        },
+    })
+
+
 def profiles_POST(request, context):
     context.status_code = 200
     return json.dumps({
@@ -68,20 +116,6 @@ def snapshot_DELETE(request, context):
     return json.dumps({
         'type': 'async',
         'operation': 'operation-abc'})
-
-
-def profile_GET(request, context):
-    name = request.path.split('/')[-1]
-    return json.dumps({
-        'type': 'sync',
-        'metadata': {
-            'name': name,
-            'description': 'An description',
-            'config': {},
-            'devices': {},
-            'used_by': [],
-        },
-    })
 
 
 RULES = [
@@ -543,8 +577,14 @@ RULES = [
             'type': 'sync',
             'metadata': [
                 'http://pylxd.test/1.0/networks/lo',
+                'http://pylxd.test/1.0/networks/eth0',
             ]},
         'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/networks$',
+    },
+    {
+        'text': networks_POST,
+        'method': 'POST',
         'url': r'^http://pylxd.test/1.0/networks$',
     },
     {
@@ -557,6 +597,21 @@ RULES = [
             }},
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/networks/lo$',
+    },
+    {
+        'text': networks_GET,
+        'method': 'GET',
+        'url': r'^http://pylxd.test/1.0/networks/eth(0|1|2)$',
+    },
+    {
+        'text': json.dumps({'type': 'sync'}),
+        'method': 'PUT',
+        'url': r'^http://pylxd.test/1.0/networks/eth0$',
+    },
+    {
+        'text': networks_DELETE,
+        'method': 'DELETE',
+        'url': r'^http://pylxd.test/1.0/networks/eth0$',
     },
 
     # Storage Pools

--- a/pylxd/tests/models/test_network.py
+++ b/pylxd/tests/models/test_network.py
@@ -11,43 +11,164 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-from pylxd import models
+import json
+
+from pylxd import models, exceptions
 from pylxd.tests import testing
 
 
 class TestNetwork(testing.PyLXDTestCase):
     """Tests for pylxd.models.Network."""
 
-    def test_all(self):
-        """A list of all networks are returned."""
-        networks = models.Network.all(self.client)
-
-        self.assertEqual(1, len(networks))
-
     def test_get(self):
-        """Return a container."""
-        name = 'lo'
-
+        """A network is fetched."""
+        name = 'eth0'
         an_network = models.Network.get(self.client, name)
 
         self.assertEqual(name, an_network.name)
 
-    def test_partial(self):
-        """A partial network is synced."""
-        an_network = models.Network(self.client, name='lo')
+    def test_get_not_found(self):
+        """LXDAPIException is raised on unknown network."""
 
-        self.assertEqual('loopback', an_network.type)
+        def not_found(_, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/networks/eth0$',
+        })
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            models.Network.get, self.client, 'eth0')
+
+    def test_get_error(self):
+        """LXDAPIException is raised on error."""
+
+        def error(_, context):
+            context.status_code = 500
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 500,
+            })
+
+        self.add_rule({
+            'text': error,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/networks/eth0$',
+        })
+
+        self.assertRaises(
+            exceptions.LXDAPIException,
+            models.Network.get, self.client, 'eth0')
+
+    def test_exists(self):
+        """True is returned if network exists."""
+        name = 'eth0'
+
+        self.assertTrue(models.Network.exists(self.client, name))
+
+    def test_not_exists(self):
+        """False is returned when network does not exist."""
+        def not_found(_, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/networks/eth0$',
+        })
+
+        name = 'eth0'
+
+        self.assertFalse(models.Network.exists(self.client, name))
+
+    def test_all(self):
+        """A list of all networks are returned."""
+        networks = models.Network.all(self.client)
+
+        self.assertEqual(2, len(networks))
+
+    def test_create(self):
+        """A new network is created."""
+        network = models.Network.create(
+            self.client, name='eth1', config={}, type_='bridge',
+            description='Network description')
+
+        self.assertIsInstance(network, models.Network)
+        self.assertEqual('eth1', network.name)
+        self.assertEqual('Network description', network.description)
+        self.assertEqual('bridge', network.type)
+        self.assertTrue(network.managed)
+
+    def test_rename(self):
+        """A network is renamed."""
+        network = models.Network.get(self.client, 'eth0')
+
+        renamed_network = network.rename('eth2')
+
+        self.assertEqual('eth2', renamed_network.name)
+
+    def test_update(self):
+        """A network is updated."""
+        network = models.Network.get(self.client, 'eth0')
+        network.config = {}
+        network.save()
+        self.assertEqual({}, network.config)
+
+    def test_fetch(self):
+        """A partial network is synced."""
+        network = self.client.networks.all()[1]
+
+        network.sync()
+
+        self.assertEqual('Network description', network.description)
+
+    def test_fetch_not_found(self):
+        """LXDAPIException is raised on bogus network fetch."""
+        def not_found(_, context):
+            context.status_code = 404
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 404})
+        self.add_rule({
+            'text': not_found,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/networks/eth0$',
+        })
+        network = models.Network(self.client, name='eth0')
+
+        self.assertRaises(exceptions.LXDAPIException, network.sync)
+
+    def test_fetch_error(self):
+        """LXDAPIException is raised on fetch error."""
+        def error(_, context):
+            context.status_code = 500
+            return json.dumps({
+                'type': 'error',
+                'error': 'Not found',
+                'error_code': 500})
+        self.add_rule({
+            'text': error,
+            'method': 'GET',
+            'url': r'^http://pylxd.test/1.0/networks/eth0$',
+        })
+        network = models.Network(self.client, name='eth0')
+
+        self.assertRaises(exceptions.LXDAPIException, network.sync)
 
     def test_delete(self):
-        """delete is not implemented in networks."""
-        an_network = models.Network(self.client, name='lo')
+        """A network is deleted."""
+        network = models.Network(self.client, name='eth0')
 
-        with self.assertRaises(NotImplementedError):
-            an_network.delete()
-
-    def test_save(self):
-        """save is not implemented in networks."""
-        an_network = models.Network(self.client, name='lo')
-
-        with self.assertRaises(NotImplementedError):
-            an_network.save()
+        network.delete()


### PR DESCRIPTION
I added support for operations on networks. I based my code on Profile model because it was quite similar. However, due to issue #302 it's not possible to test my changes using 'run_integration_tests' script on Ubuntu 16.04 and after switching to 17.10 my tests are passing but few other are failing (due to missing storage pool).