### PR TITLE
Keep pbr dependency in setup_requires (fixes #308, follows #309)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,10 @@ except ImportError:
     pass
 
 setuptools.setup(
-    install_requires=[
+    setup_requires=[
         'pbr>=1.8',
+    ],
+    install_requires=[
         'requests!=2.8.0,>=2.5.2',
         # >= 0.1.5 needed for HTTP_PROXY support
         'requests-unixsocket>=0.1.5',


### PR DESCRIPTION
Follow up on #309 to fix #308 but keep build time dependency `pbr` in `setup_requires` and remove the following warning:

```
./.venv/bin/python setup.py --help                                                            
/usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'pbr'                                                                                                                      
  warnings.warn(msg)                                                                                                                                                                                           
Common commands: (see '--help-commands' for more)                                                                                                                                                              
                                                                                                                                                                                                               
  setup.py build      will build the package underneath 'build/'                                                                                                                                               
  setup.py install    will install the package                                                                                                                                                                 
                                                                                                                                                                                                               
Global options:                                                                                                   
[...]
```
