### PR TITLE
Update documetation

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -173,6 +173,7 @@ A container object (returned by `get` or `all`) has the following methods:
 
 To create a new snapshot, use `create` with a `name` argument. If you want
 to capture the contents of RAM in the snapshot, you can use `stateful=True`.
+
 .. note:: Your LXD requires a relatively recent version of CRIU for this.
 
 .. code-block:: python

--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -19,7 +19,7 @@ methods:
 And create through the following methods, there's also a copy method on an
 image:
 
-  - `create(data, public=False, wait=False)` - Create a new image. The first
+  - `create(data, public=False, wait=True)` - Create a new image. The first
     argument is the binary data of the image itself. If the image is public,
     set `public` to `True`.
   - `create_from_simplestreams(server, alias, public=False, auto_update=False, wait=False)` -
@@ -93,7 +93,7 @@ you may also want to `wait=True`.
 
 .. code-block:: python
 
-    >>> image_data = open('an_image.tar.gz').read()
+    >>> image_data = open('an_image.tar.gz', 'rb').read()
     >>> image = client.images.create(image_data, public=True, wait=True)
     >>> image.fingerprint
     'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'

--- a/doc/source/operations.rst
+++ b/doc/source/operations.rst
@@ -13,7 +13,7 @@ Manager methods
 
 Operations can be queried through the following client manager methods:
 
-  - `get()` - Get a specific network, by its name.
+  - `get()` - Get a specific operation, by its id.
   - `wait_for_operation()` - get an operation, but wait until it is complete
     before returning the operation object.
 


### PR DESCRIPTION
There are four changes :
1. containers.rst:
  Add a newline to ensure syntax of admonition will take effect.
2. image.rst:
  a) The default value of *wait* argument in create() is *True*. (refs [image.py#L101](https://github.com/lxc/pylxd/blob/master/pylxd/models/image.py#L101))
  b) The first argument in create() is the binary data of the image. Therefore, *image_data* should be opened in 'rb' mode. Or you will get an error like:
```
>>> image_data = open('an_image.tar.gz').read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.4/codecs.py", line 319, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 0: invalid start byte
```
3. operations.rst:
  Correct typo.
