### PR TITLE
Added example on how to use the migrate API

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -144,6 +144,25 @@ To get state information such as a network address.
     {'family': 'inet', 'address': '10.251.77.182', 'netmask': '24', 'scope': 'global'}
 
 
+To migrate a container between two servers, first you need to create a client certificate in order to connect to the remote server
+
+    openssl req -newkey rsa:2048 -nodes -keyout lxd.key -out lxd.csr
+    openssl x509 -signkey lxd.key -in lxd.csr -req -days 365 -out lxd.crt
+
+Then you need to connect to both the destination server and the source server,
+the source server has to be reachable by the destination server otherwise the migration will fail due to a websocket error
+
+.. code-block:: python
+
+    from pylxd import Client
+
+    client_source=Client(endpoint='https://192.168.1.104:8443',cert=('lxd.crt','lxd.key'),verify=False)
+    client_destination=Client(endpoint='https://192.168.1.106:8443',cert=('lxd.crt','lxd.key'),verify=False)
+    cont = client_source.containers.get('testm')
+    cont.migrate(client_destination,wait=True)
+
+This will migrate the container from source server to destination server
+
 Container Snapshots
 -------------------
 

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -421,9 +421,25 @@ class Container(model.Model):
         """
         if self.api.scheme in ('http+unix',):
             raise ValueError('Cannot migrate from a local client connection')
+        
+        if self.status.upper() == 'RUNNING':
+            try:
+                res = new_client.containers.create(
+                    self.generate_migration_data(), wait=wait)
+            except LXDAPIException as e:
+                if '{}'.format(e) == "The container is already running":
+                    self.delete()
+                    return new_client.containers.get(self.name)
+                else:
+                    raise e
+            self.delete()
+            return res
+        else:
+           res = new_client.containers.create(
+                    self.generate_migration_data(), wait=wait)
+           self.delete()
+           return res
 
-        return new_client.containers.create(
-            self.generate_migration_data(), wait=wait)
 
     def generate_migration_data(self):
         """Generate the migration data.

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -421,25 +421,9 @@ class Container(model.Model):
         """
         if self.api.scheme in ('http+unix',):
             raise ValueError('Cannot migrate from a local client connection')
-        
-        if self.status.upper() == 'RUNNING':
-            try:
-                res = new_client.containers.create(
-                    self.generate_migration_data(), wait=wait)
-            except LXDAPIException as e:
-                if '{}'.format(e) == "The container is already running":
-                    self.delete()
-                    return new_client.containers.get(self.name)
-                else:
-                    raise e
-            self.delete()
-            return res
-        else:
-           res = new_client.containers.create(
-                    self.generate_migration_data(), wait=wait)
-           self.delete()
-           return res
 
+        return new_client.containers.create(
+            self.generate_migration_data(), wait=wait)
 
     def generate_migration_data(self):
         """Generate the migration data.


### PR DESCRIPTION
I have added the example on how to migrate a container using pylxd 
As agreed in #315
The migration fails due to an error but the example should be correct 