### PR TITLE
Fix execution times in lxd 3.0.1 and add pipelining support to execute

### DIFF
--- a/integration/test_containers.py
+++ b/integration/test_containers.py
@@ -178,6 +178,25 @@ class TestContainer(IntegrationTestCase):
         self.assertEqual('qué', result.stdout)
         self.assertEqual('', result.stderr)
 
+    def test_execute_pipes(self):
+        """A command receives data from stdin and write to stdout handler"""
+        self.container.start(wait=True)
+        self.addCleanup(self.container.stop, wait=True)
+        test_msg = "Hello world!\n"
+        stdout_msgs = []
+
+        def stdout_handler(msg):
+            stdout_msgs.append(msg)
+
+        result = self.container.execute(
+            ['cat', '-'], stdin_payload=test_msg, stdout_handler=stdout_handler
+        )
+
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(test_msg, result.stdout)
+        self.assertEqual('', result.stderr)
+        self.assertEqual(stdout_msgs, [test_msg])
+
     def test_publish(self):
         """A container is published."""
         image = self.container.publish(wait=True)


### PR DESCRIPTION
Fix issue #316 and issue #244 

It works (tox and integration tests) with lxd versions 3.0.1 and 2.0.11

Can be tested with this script to view some new features:

```python
from pylxd import Client
import io
import logging

logger = logging.getLogger(__name__)
handler = logging.StreamHandler()
handler.setFormatter(
    logging.Formatter("%(relativeCreated)6d %(threadName)s %(message)s")
)
logger.addHandler(handler)
logger.setLevel(logging.INFO)

c = Client()
cont = c.containers.all()[0]
if cont.status != "Running":
    cont.start(wait=True)

# Stdin demo
logger.info(cont.execute(["cat", "-"], stdin_payload=open(__file__)).stdout)
logger.info(cont.execute(["cat", "-"], stdin_payload="hola"))
logger.info(cont.execute(["cat", "-"], stdin_payload=b"hola"))
logger.info(cont.execute(["cat", "-"], stdin_payload=io.StringIO("hola")))
logger.info(cont.execute(["cat", "-"], stdin_payload=io.BytesIO(b"hola")))


# Stdout demo
def handle_out(msg):
    logger.info(msg)


cont.execute(
    [
        "bash", "-c",
        'while read  c; do echo "$c"; sleep 1; done < /etc/hosts'
    ], stdout_handler=handle_out
)
```

`container.execute` is retro-compatible but adds pipeline features. Now you can communicate with your commands via stdin and manage output while command is executing.