### PR TITLE
Allow wait argument to be True/False in create_from_simplestreams and create_from_url

### DIFF
--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -22,9 +22,9 @@ image:
   - `create(data, public=False, wait=True)` - Create a new image. The first
     argument is the binary data of the image itself. If the image is public,
     set `public` to `True`.
-  - `create_from_simplestreams(server, alias, public=False, auto_update=False, wait=False)` -
+  - `create_from_simplestreams(server, alias, public=False, auto_update=False, wait=True)` -
     Create an image from simplestreams.
-  - `create_from_url(url, public=False, auto_update=False, wait=False)` -
+  - `create_from_url(url, public=False, auto_update=False, wait=True)` -
     Create an image from a url.
 
 Image attributes

--- a/integration/test_images.py
+++ b/integration/test_images.py
@@ -54,6 +54,31 @@ class TestImages(IntegrationTestCase):
 
         self.assertEqual(fingerprint, image.fingerprint)
 
+    def test_create_from_simplestreams(self):
+        """An image is created from simplestreams."""
+        image = self.client.images.create_from_simplestreams(
+            'https://cloud-images.ubuntu.com/releases',
+            'trusty/amd64'
+        )
+        self.addCleanup(self.delete_image, image.fingerprint)
+
+        self.assertEqual(
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            image.fingerprint
+        )
+
+    def test_create_from_url(self):
+        """An image is created from an url."""
+        image = self.client.images.create_from_url(
+            'https://dl.stgraber.org/lxd'
+        )
+        self.addCleanup(self.delete_image, image.fingerprint)
+
+        self.assertEqual(
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            image.fingerprint
+        )
+
 
 class TestImage(IntegrationTestCase):
     """Tests for Image."""

--- a/pylxd/models/image.py
+++ b/pylxd/models/image.py
@@ -137,7 +137,7 @@ class Image(model.Model):
 
     @classmethod
     def create_from_simplestreams(cls, client, server, alias,
-                                  public=False, auto_update=False):
+                                  public=False, auto_update=False, wait=True):
         """Copy an image from simplestreams."""
         config = {
             'public': public,
@@ -152,13 +152,14 @@ class Image(model.Model):
             }
         }
 
-        op = _image_create_from_config(client, config, wait=True)
+        op = _image_create_from_config(client, config, wait)
 
-        return client.images.get(op.metadata['fingerprint'])
+        if wait:
+            return client.images.get(op.metadata['fingerprint'])
 
     @classmethod
     def create_from_url(cls, client, url,
-                        public=False, auto_update=False):
+                        public=False, auto_update=False, wait=True):
         """Copy an image from an url."""
         config = {
             'public': public,
@@ -171,9 +172,10 @@ class Image(model.Model):
             }
         }
 
-        op = _image_create_from_config(client, config, wait=True)
+        op = _image_create_from_config(client, config, wait)
 
-        return client.images.get(op.metadata['fingerprint'])
+        if wait:
+            return client.images.get(op.metadata['fingerprint'])
 
     def export(self):
         """Export the image.


### PR DESCRIPTION
In pylxd doc, the default value of `wait` argument in `create_from_simplestreams()` is `False`,
but it's forcibly set to True in [source code](https://github.com/lxc/pylxd/blob/master/pylxd/models/image.py#L155).
The problem also happens to `create_from_url()`.

As mentioned in offical REST API [document](https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10images), creating a new image is an async operation.
Therefore, I fix `wait` argument in this PR.

When `wait` is True, the function will not return until the operation is completed.
On the other hand, it will return right away when `wait` if False