### PR TITLE
Tidy up integration script tests

### DIFF
--- a/integration/run_integration_tests
+++ b/integration/run_integration_tests
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+_release=$(lsb_release -c | cut -f 2)
+
+if [[ "${_release}" == "bionic" ]]; then
+	echo "Running Bionic (18:04) integration tests"
+	exec ${_dir}/run_integration_tests-18-04
+else
+	echo "Running Xenial (16:04) integration tests"
+	exec ${_dir}/run_integration_tests-16-04
+fi

--- a/integration/run_integration_tests
+++ b/integration/run_integration_tests
@@ -2,7 +2,7 @@
 set -ex
 
 _dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
-_release=$(lsb_release -c | cut -f 2)
+_release=$(lsb_release -cs)
 
 if [[ "${_release}" == "bionic" ]]; then
 	echo "Running Bionic (18:04) integration tests"

--- a/integration/run_integration_tests-16-04
+++ b/integration/run_integration_tests-16-04
@@ -17,6 +17,6 @@ lxc exec $CONTAINER_NAME -- lxc config set core.https_address [::]
 lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
 # NOTE: rockstar (13 Sep 2016) - --recursive is not supported in lxd <2.1, so
 # until we have pervasive support for that, we'll do this tar hack.
-tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
+cd .. && tar cf - ../* ../.git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
 lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
 lxc delete --force $CONTAINER_NAME

--- a/integration/run_integration_tests-18-04
+++ b/integration/run_integration_tests-18-04
@@ -31,6 +31,6 @@ lxc exec $CONTAINER_NAME -- lxc profile device add default root disk path=/ pool
 lxc exec $CONTAINER_NAME -- mkdir -p /opt/pylxd
 # NOTE: rockstar (13 Sep 2016) - --recursive is not supported in lxd <2.1, so
 # until we have pervasive support for that, we'll do this tar hack.
-tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
+cd .. && tar cf - * .git | lxc exec $CONTAINER_NAME -- tar xf - -C /opt/pylxd
 lxc exec $CONTAINER_NAME -- /bin/sh -c "cd /opt/pylxd && tox -eintegration"
 lxc delete --force $CONTAINER_NAME

--- a/run_integration_tests
+++ b/run_integration_tests
@@ -1,1 +1,0 @@
-run_integration_tests-18-04


### PR DESCRIPTION
Move the scripts to the integration/ directory, and enable the
`run_integration_tests` script to choose the Ubuntu version specific
script based on the output of lsb_release.