### PR TITLE
Bump version to 2.2.9 for dev and fix some pep8 issues

### DIFF
--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -469,7 +469,7 @@ class TestFiles(testing.PyLXDTestCase):
         self.add_rule({
             'method': 'DELETE',
             'url': (r'^http://pylxd.test/1.0/containers/an-container/files'
-                    '\?path=%2Fsome%2Ffile$')
+                    r'\?path=%2Fsome%2Ffile$')
         })
         self.container.files.delete('/some/file')
 
@@ -481,7 +481,7 @@ class TestFiles(testing.PyLXDTestCase):
             'text': responder,
             'method': 'DELETE',
             'url': (r'^http://pylxd.test/1.0/containers/an-container/files'
-                    '\?path=%2Fsome%2Ffile%2Fnot%2Ffound$')
+                    r'\?path=%2Fsome%2Ffile%2Fnot%2Ffound$')
         })
         with self.assertRaises(exceptions.LXDAPIException):
             self.container.files.delete('/some/file/not/found')
@@ -499,7 +499,7 @@ class TestFiles(testing.PyLXDTestCase):
             'text': capture,
             'method': 'POST',
             'url': (r'^http://pylxd.test/1.0/containers/an-container/files'
-                    '\?path=%2Ftmp%2Fputted$'),
+                    r'\?path=%2Ftmp%2Fputted$'),
         })
 
         data = 'The quick brown fox'
@@ -550,7 +550,7 @@ class TestFiles(testing.PyLXDTestCase):
 
         with tempdir() as _dir:
             base = (r'^http://pylxd.test/1.0/containers/'
-                    'an-container/files\?path=')
+                    r'an-container/files\?path=')
             rules = [
                 {
                     'text': capture,
@@ -602,7 +602,7 @@ class TestFiles(testing.PyLXDTestCase):
             'text': not_found,
             'method': 'GET',
             'url': (r'^http://pylxd.test/1.0/containers/an-container/files'
-                    '\?path=%2Ftmp%2Fgetted$'),
+                    r'\?path=%2Ftmp%2Fgetted$'),
         }
         self.add_rule(rule)
 
@@ -618,7 +618,7 @@ class TestFiles(testing.PyLXDTestCase):
             'text': not_found,
             'method': 'GET',
             'url': (r'^http://pylxd.test/1.0/containers/an-container/files'
-                    '\?path=%2Ftmp%2Fgetted$'),
+                    r'\?path=%2Ftmp%2Fgetted$'),
         }
         self.add_rule(rule)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.8
+version = 2.2.9
 description-file =
     README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps = -r{toxinidir}/requirements.txt
 commands = nosetests --with-coverage --cover-package=pylxd pylxd
 
 [testenv:pep8]
-commands = flake8 --ignore=E123,E125
+commands = flake8 --ignore=E123,E125,W504
 
 [testenv:integration]
 commands = nosetests integration
@@ -22,6 +22,6 @@ commands = nosetests integration
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125
+ignore = E123,E125,W504
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build


### PR DESCRIPTION
PEP8 keeps adding new default warnings, so we have to either fix
the code of config them out.  In this case, a bit of both.

Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>