### PR TITLE
Fix race condition in 2.2.8 generating long pauses

### DIFF
--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -21,6 +21,7 @@ from six.moves.urllib import parse
 try:
     from ws4py.client import WebSocketBaseClient
     from ws4py.manager import WebSocketManager
+    from ws4py.messaging import BinaryMessage
     _ws4py_installed = True
 except ImportError:  # pragma: no cover
     WebSocketBaseClient = object
@@ -520,6 +521,8 @@ class _CommandWebsocketClient(WebSocketBaseClient):  # pragma: no cover
         if self.handler:
             self.handler(self._maybe_decode(message.data))
         self.buffer.append(message.data)
+        if isinstance(message, BinaryMessage):
+            self.manager.remove(self)
 
     def _maybe_decode(self, buffer):
         if self.decode and buffer is not None:


### PR DESCRIPTION
Signed-off-by: lasizoillo <lasizoillo@gmail.com>

LXD sends TextMessage frames until the last one, then send a BinaryMessage and closes connection. If connection is closed no read events can't arrive to EPollPoller and ws4py doesn't read more data. But ws4py get into a loop in some cases waiting for streaming data to complete a message frame. There are another infinite loop waiting to ws4py to drain connection buffer.

I hope this fix resolve all corner cases. If not, I hope be more free to fix it sooner.