### PR TITLE
Added compatibility with operations project values

### DIFF
--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover
 from pylxd import managers
 from pylxd.exceptions import LXDAPIException
 from pylxd.models import _model as model
+from pylxd.models.operation import Operation
 
 if six.PY2:
     # Python2.7 doesn't have this natively
@@ -397,8 +398,8 @@ class Container(model.Model):
         })
 
         fds = response.json()['metadata']['metadata']['fds']
-        operation_id = response.json()['operation']\
-            .split('/')[-1].split('?')[0]
+        operation_id = \
+            Operation.extract_operation_id(response.json()['operation'])
         parsed = parse.urlparse(
             self.client.api.operations[operation_id].websocket._api_endpoint)
 

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -397,7 +397,8 @@ class Container(model.Model):
         })
 
         fds = response.json()['metadata']['metadata']['fds']
-        operation_id = response.json()['operation'].split('/')[-1]
+        operation_id = response.json()['operation']\
+            .split('/')[-1].split('?')[0]
         parsed = parse.urlparse(
             self.client.api.operations[operation_id].websocket._api_endpoint)
 

--- a/pylxd/models/operation.py
+++ b/pylxd/models/operation.py
@@ -13,8 +13,10 @@
 #    under the License.
 
 import warnings
+import os
 
 from pylxd import exceptions
+from six.moves.urllib import parse
 
 
 class Operation(object):
@@ -33,12 +35,13 @@ class Operation(object):
         return cls.get(client, operation.id)
 
     @classmethod
+    def extract_operation_id(cls, s):
+        return os.path.split(parse.urlparse(s).path)[-1]
+
+    @classmethod
     def get(cls, client, operation_id):
         """Get an operation."""
-        if operation_id.startswith('/'):
-            operation_id = operation_id.split('/')[-1]
-        if '?' in operation_id:
-            operation_id = operation_id.split('?')[0]
+        operation_id = cls.extract_operation_id(operation_id)
         response = client.api.operations[operation_id].get()
         return cls(_client=client, **response.json()['metadata'])
 

--- a/pylxd/models/operation.py
+++ b/pylxd/models/operation.py
@@ -37,6 +37,8 @@ class Operation(object):
         """Get an operation."""
         if operation_id.startswith('/'):
             operation_id = operation_id.split('/')[-1]
+        if '?' in operation_id:
+            operation_id = operation_id.split('?')[0]
         response = client.api.operations[operation_id].get()
         return cls(_client=client, **response.json()['metadata'])
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -5,7 +5,7 @@ def containers_POST(request, context):
     context.status_code = 202
     return json.dumps({
         'type': 'async',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 def container_POST(request, context):
@@ -13,11 +13,11 @@ def container_POST(request, context):
     if not request.json().get('migration', False):
         return {
             'type': 'async',
-            'operation': 'operation-abc'}
+            'operation': '/1.0/operations/operation-abc?project=default'}
     else:
         return {
             'type': 'async',
-            'operation': 'operation-abc',
+            'operation': '/1.0/operations/operation-abc?project=default',
             'metadata': {
                 'metadata': {
                     '0': 'abc',
@@ -32,21 +32,22 @@ def container_DELETE(request, context):
     context.status_code = 202
     return json.dumps({
         'type': 'async',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 def images_POST(request, context):
     context.status_code = 202
     return json.dumps({
         'type': 'async',
-        'operation': 'images-create-operation'})
+        'operation': '/1.0/operations/images-create-operation?project=default'
+    })
 
 
 def image_DELETE(request, context):
     context.status_code = 202
     return json.dumps({
         'type': 'async',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 def networks_GET(request, _):
@@ -80,7 +81,7 @@ def networks_DELETE(_, context):
     context.status_code = 202
     return json.dumps({
         'type': 'sync',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 def profile_GET(request, context):
@@ -108,14 +109,14 @@ def profile_DELETE(request, context):
     context.status_code = 200
     return json.dumps({
         'type': 'sync',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 def snapshot_DELETE(request, context):
     context.status_code = 202
     return json.dumps({
         'type': 'async',
-        'operation': 'operation-abc'})
+        'operation': '/1.0/operations/operation-abc?project=default'})
 
 
 RULES = [
@@ -439,7 +440,7 @@ RULES = [
         'status_code': 202,
         'json': {
             'type': 'async',
-            'operation': 'operation-abc'},
+            'operation': '/1.0/operations/operation-abc?project=default'},
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/containers/an-container/state$',  # NOQA
     },
@@ -451,7 +452,7 @@ RULES = [
     {
         'text': json.dumps({
             'type': 'async',
-            'operation': 'operation-abc'}),
+            'operation': '/1.0/operations/operation-abc?project=default'}),
         'status_code': 202,
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/containers/an-container$',
@@ -474,7 +475,7 @@ RULES = [
                     }
                 },
             },
-            'operation': 'operation-abc'},
+            'operation': '/1.0/operations/operation-abc?project=default'},
         'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/exec$',  # NOQA
@@ -493,7 +494,7 @@ RULES = [
     {
         'text': json.dumps({
             'type': 'async',
-            'operation': 'operation-abc'}),
+            'operation': '/1.0/operations/operation-abc?project=default'}),
         'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots$',  # NOQA
@@ -511,7 +512,7 @@ RULES = [
     {
         'text': json.dumps({
             'type': 'async',
-            'operation': 'operation-abc'}),
+            'operation': '/1.0/operations/operation-abc?project=default'}),
         'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/snapshots/an-snapshot$',  # NOQA
@@ -636,7 +637,9 @@ RULES = [
         'url': r'^http://pylxd2.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
     },
     {
-        'text': json.dumps({'type': 'async', 'operation': 'operation-abc'}),
+        'text': json.dumps({
+            'type': 'async',
+            'operation': '/1.0/operations/operation-abc?project=default'}),
         'status_code': 202,
         'method': 'PUT',
         'url': r'^http://pylxd.test/1.0/images/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$',  # NOQA
@@ -865,7 +868,8 @@ RULES = [
     },
     # create an async storage volume
     {
-        'json': {'type': 'async', 'operation': 'operation-abc'},
+        'json': {'type': 'async',
+                 'operation': '/1.0/operations/operation-abc?project=default'},
         'status_code': 202,
         'method': 'POST',
         'url': (r'^http://pylxd.test/1.0/storage-pools/'
@@ -909,7 +913,7 @@ RULES = [
     {
         'json': {
             "type": "async",
-            "operation": "operation-abc",
+            "operation": "/1.0/operations/operation-abc?project=default",
             "metadata": {
                 "control": "secret1",
                 "fs": "secret2"

--- a/pylxd/tests/models/test_operation.py
+++ b/pylxd/tests/models/test_operation.py
@@ -37,6 +37,14 @@ class TestOperation(testing.PyLXDTestCase):
 
         self.assertEqual('operation-abc', an_operation.id)
 
+    def test_get_full_path_and_project(self):
+        """Return an operation even if the full path is specified."""
+        name = '/1.0/operations/operation-abc?project=default'
+
+        an_operation = models.Operation.get(self.client, name)
+
+        self.assertEqual('operation-abc', an_operation.id)
+
     def test_wait_with_error(self):
         """If the operation errors, wait raises an exception."""
         def error(request, context):


### PR DESCRIPTION
the LXD Rest api returns an operation id with the query string
`?project=default` to notify in which project the operation belongs. This
was not sufficiently cut away by `.split('/')[-1]`
but also needed a subsequent `.split('?')[0]`

The Mock_lxd has been adapted to test for this feature

In the `container.execute` the `operation_id` is needed directly, where it
is fixed too

Signed-off-by: Felix Engelmann <fe-github@nlogn.org>