### PR TITLE
Interactive Execute on Container

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -64,8 +64,8 @@ Container methods
     a list, in the form of `subprocess.Popen` with each item of the command
     as a separate item in the list. Returns a tuple of `(exit_code, stdout, stderr)`.
     This method will block while the command is executed.
-  - `interactive_execute` - Execute a command on the container. It will return
-    an interactive websocket and the execution only starts after a client connected to the websocket.
+  - `raw_interactive_execute` - Execute a command on the container. It will return
+    an url to an interactive websocket and the execution only starts after a client connected to the websocket.
   - `migrate` - Migrate the container. The first argument is a client
     connection to the destination server. This call is asynchronous, so
     `wait=True` is optional. The container on the new client is returned.
@@ -164,6 +164,20 @@ the source server has to be reachable by the destination server otherwise the mi
     cont.migrate(client_destination,wait=True)
 
 This will migrate the container from source server to destination server
+
+If you want an interactive shell in the container, you can attach to it via a websocket.
+
+.. code-block:: python
+
+    >>> res = container.raw_interactive_execute(['/bin/bash'])
+    >>> res
+    {
+        "name": "container-name",
+        "ws": "/1.0/operations/adbaab82-afd2-450c-a67e-274726e875b1/websocket?secret=ef3dbdc103ec5c90fc6359c8e087dcaf1bc3eb46c76117289f34a8f949e08d87",
+        "control": "/1.0/operations/adbaab82-afd2-450c-a67e-274726e875b1/websocket?secret=dbbc67833009339d45140671773ac55b513e78b219f9f39609247a2d10458084"
+    }
+
+You can connect to this urls from e.g. https://xtermjs.org/ .
 
 Container Snapshots
 -------------------

--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -64,6 +64,8 @@ Container methods
     a list, in the form of `subprocess.Popen` with each item of the command
     as a separate item in the list. Returns a tuple of `(exit_code, stdout, stderr)`.
     This method will block while the command is executed.
+  - `interactive_execute` - Execute a command on the container. It will return
+    an interactive websocket and the execution only starts after a client connected to the websocket.
   - `migrate` - Migrate the container. The first argument is a client
     connection to the destination server. This call is asynchronous, so
     `wait=True` is optional. The container on the new client is returned.

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -440,17 +440,15 @@ class Container(model.Model):
     def interactive_execute(
             self, commands, environment=None
     ):
-        """Execute a command on the container interactively and return websocket.
+        """Execute a command on the container interactively and returns websockets.
 
-        In pylxd 2.2, this method will be renamed `execute` and the existing
-        `execute` method removed.
-
-        :param commands: The command and arguments as a list of strings (most likely a shell)
+        :param commands: The command and arguments as a list of strings
+           (most likely a shell)
         :type commands: [str]
         :param environment: The environment variables to pass with the command
         :type environment: {str: str}
-        :returns: A link to an interactive websocket and a control socket
-        :rtype: dict
+        :returns: Two urls to an interactive websocket and a control socket
+        :rtype: {'ws':str,'control':str}
         """
         if not _ws4py_installed:
             raise ValueError(
@@ -475,7 +473,7 @@ class Container(model.Model):
             self.client.api.operations[operation_id].websocket._api_endpoint)
 
         return {'ws': '{}?secret={}'.format(parsed.path, fds['0']),
-                'control': '{}?secret={}'.format(parsed.path, fds['control']),}
+                'control': '{}?secret={}'.format(parsed.path, fds['control'])}
 
     def migrate(self, new_client, wait=False):
         """Migrate a container.

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -438,9 +438,10 @@ class Container(model.Model):
                 operation.metadata['return'], stdout.data, stderr.data)
 
     def raw_interactive_execute(self, commands, environment=None):
-        """Execute a command on the container interactively and returns urls to websockets.
-        The urls contain a secret uuid, and can be accesses without further authentication.
-        The caller has to open and manage the websockets themselves.
+        """Execute a command on the container interactively and returns
+        urls to websockets. The urls contain a secret uuid, and can be accesses
+        without further authentication. The caller has to open and manage
+        the websockets themselves.
 
         :param commands: The command and arguments as a list of strings
            (most likely a shell)

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -437,10 +437,10 @@ class Container(model.Model):
             return _ContainerExecuteResult(
                 operation.metadata['return'], stdout.data, stderr.data)
 
-    def interactive_execute(
-            self, commands, environment=None
-    ):
-        """Execute a command on the container interactively and returns websockets.
+    def raw_interactive_execute(self, commands, environment=None):
+        """Execute a command on the container interactively and returns urls to websockets.
+        The urls contain a secret uuid, and can be accesses without further authentication.
+        The caller has to open and manage the websockets themselves.
 
         :param commands: The command and arguments as a list of strings
            (most likely a shell)

--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -450,9 +450,6 @@ class Container(model.Model):
         :returns: Two urls to an interactive websocket and a control socket
         :rtype: {'ws':str,'control':str}
         """
-        if not _ws4py_installed:
-            raise ValueError(
-                'This feature requires the optional ws4py library.')
         if isinstance(commands, six.string_types):
             raise TypeError("First argument must be a list.")
 

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -241,8 +241,10 @@ class TestContainer(testing.PyLXDTestCase):
 
         result = an_container.interactive_execute(['/bin/bash'])
 
-        self.assertEqual(result['ws'],'/1.0/operations/operation-abc/websocket?secret=abc')
-        self.assertEqual(result['control'],'/1.0/operations/operation-abc/websocket?secret=jkl')
+        self.assertEqual(result['ws'],
+                         '/1.0/operations/operation-abc/websocket?secret=abc')
+        self.assertEqual(result['control'],
+                         '/1.0/operations/operation-abc/websocket?secret=jkl')
 
     def test_migrate(self):
         """A container is migrated."""

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -246,6 +246,16 @@ class TestContainer(testing.PyLXDTestCase):
         self.assertEqual(result['control'],
                          '/1.0/operations/operation-abc/websocket?secret=jkl')
 
+    def test_interactive_execute_env(self):
+        an_container = models.Container(self.client, name='an-container')
+
+        result = an_container.interactive_execute(['/bin/bash'], {"PATH": "/"})
+
+        self.assertEqual(result['ws'],
+                         '/1.0/operations/operation-abc/websocket?secret=abc')
+        self.assertEqual(result['control'],
+                         '/1.0/operations/operation-abc/websocket?secret=jkl')
+
     def test_interactive_execute_string(self):
         """A command passed as string raises a TypeError."""
         an_container = models.Container(

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -236,6 +236,14 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertRaises(TypeError, an_container.execute, 'apt-get update')
 
+    def test_interactive_execute(self):
+        an_container = models.Container(self.client, name='an-container')
+
+        result = an_container.interactive_execute(['/bin/bash'])
+
+        self.assertEqual(result['ws'],'/1.0/operations/operation-abc/websocket?secret=abc')
+        self.assertEqual(result['control'],'/1.0/operations/operation-abc/websocket?secret=jkl')
+
     def test_migrate(self):
         """A container is migrated."""
         from pylxd.client import Client

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -246,6 +246,15 @@ class TestContainer(testing.PyLXDTestCase):
         self.assertEqual(result['control'],
                          '/1.0/operations/operation-abc/websocket?secret=jkl')
 
+    def test_interactive_execute_string(self):
+        """A command passed as string raises a TypeError."""
+        an_container = models.Container(
+            self.client, name='an-container')
+
+        self.assertRaises(TypeError,
+                          an_container.interactive_execute,
+                          'apt-get update')
+
     def test_migrate(self):
         """A container is migrated."""
         from pylxd.client import Client

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -236,33 +236,34 @@ class TestContainer(testing.PyLXDTestCase):
 
         self.assertRaises(TypeError, an_container.execute, 'apt-get update')
 
-    def test_interactive_execute(self):
+    def test_raw_interactive_execute(self):
         an_container = models.Container(self.client, name='an-container')
 
-        result = an_container.interactive_execute(['/bin/bash'])
+        result = an_container.raw_interactive_execute(['/bin/bash'])
 
         self.assertEqual(result['ws'],
                          '/1.0/operations/operation-abc/websocket?secret=abc')
         self.assertEqual(result['control'],
                          '/1.0/operations/operation-abc/websocket?secret=jkl')
 
-    def test_interactive_execute_env(self):
+    def test_raw_interactive_execute_env(self):
         an_container = models.Container(self.client, name='an-container')
 
-        result = an_container.interactive_execute(['/bin/bash'], {"PATH": "/"})
+        result = an_container.raw_interactive_execute(['/bin/bash'],
+                                                      {"PATH": "/"})
 
         self.assertEqual(result['ws'],
                          '/1.0/operations/operation-abc/websocket?secret=abc')
         self.assertEqual(result['control'],
                          '/1.0/operations/operation-abc/websocket?secret=jkl')
 
-    def test_interactive_execute_string(self):
+    def test_raw_interactive_execute_string(self):
         """A command passed as string raises a TypeError."""
         an_container = models.Container(
             self.client, name='an-container')
 
         self.assertRaises(TypeError,
-                          an_container.interactive_execute,
+                          an_container.raw_interactive_execute,
                           'apt-get update')
 
     def test_migrate(self):


### PR DESCRIPTION
It might be interesting to get the websockets to interact with a container, e.g. on a shell.
Therefore interactive_execute on a container returns a data and control websocket. By design of lxd, they include a secret, so no additional authentication is required to connect to them. They are then perfect to be passed to a web terminal.