### PR TITLE
Update requests to minimum version 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr>=1.6
 python-dateutil>=2.4.2
 six>=1.9.0
 ws4py!=0.3.5,>=0.3.4  # 0.3.5 is broken for websocket support
-requests!=2.8.0,!=2.12.0,!=2.12.1,>=2.5.2
+requests>=2.20.0
 requests-unixsocket>=0.1.5
 requests-toolbelt>=0.8.0
 cryptography!=1.3.0,>=1.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         'pbr>=1.8',
     ],
     install_requires=[
-        'requests!=2.8.0,>=2.5.2',
+        'requests>=2.20.0',
         # >= 0.1.5 needed for HTTP_PROXY support
         'requests-unixsocket>=0.1.5',
     ],


### PR DESCRIPTION
This is due to a medium security alert: CVE-2018-18074.
https://nvd.nist.gov/vuln/detail/CVE-2018-18074