### PR TITLE
Add restore snapshot methods

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -71,6 +71,7 @@ Container methods
     `wait=True` is optional. The container on the new client is returned.
   - `publish` - Publish the container as an image.  Note the container must be stopped
     in order to use this method.  If `wait=True` is passed, then the image is returned.
+  - `restore_snapshot` - Restore a snapshot by name.
 
 
 Examples
@@ -196,6 +197,7 @@ A container object (returned by `get` or `all`) has the following methods:
     image from the snapshot is bigger than the logical volume that is allocated
     by lxc.  See https://github.com/lxc/lxd/issues/2201 for more details.  The solution
     is to increase the `storage.lvm_volume_size` parameter in lxc.
+  - `restore` - restore the container to this snapshot.
 
 .. code-block:: python
 

--- a/pylxd/tests/mock_lxd.py
+++ b/pylxd/tests/mock_lxd.py
@@ -28,6 +28,14 @@ def container_POST(request, context):
         }
 
 
+def container_PUT(request, context):
+    context.status_code = 202
+    return {
+        'type': 'async',
+        'operation': '/1.0/operations/operation-abc?project=default'
+    }
+
+
 def container_DELETE(request, context):
     context.status_code = 202
     return json.dumps({
@@ -260,7 +268,7 @@ RULES = [
         'method': 'GET',
         'url': r'^http://pylxd.test/1.0/containers$',
     },
-{
+    {
         'text': json.dumps({
             'type': 'sync',
             'metadata': [
@@ -332,7 +340,7 @@ RULES = [
         'method': 'GET',
         'url': r'^http://pylxd2.test/1.0/containers/an-container$',
     },
-{
+    {
         'json': {
             'type': 'sync',
             'metadata': {
@@ -479,6 +487,11 @@ RULES = [
         'status_code': 202,
         'method': 'POST',
         'url': r'^http://pylxd.test/1.0/containers/an-container/exec$',  # NOQA
+    },
+    {
+        'json': container_PUT,
+        'method': 'PUT',
+        'url': r'^http://pylxd.test/1.0/containers/an-container$',
     },
 
     # Container Snapshots

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -390,6 +390,12 @@ class TestContainer(testing.PyLXDTestCase):
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
             image.fingerprint)
 
+    def test_restore_snapshot(self):
+        """Snapshots can be restored"""
+        an_container = models.Container(
+            self.client, name='an-container')
+        an_container.restore_snapshot('thing')
+
 
 class TestContainerState(testing.PyLXDTestCase):
     """Tests for pylxd.models.ContainerState."""
@@ -539,6 +545,13 @@ class TestSnapshot(testing.PyLXDTestCase):
         self.assertEqual(
             'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
             image.fingerprint)
+
+    def test_restore_snapshot(self):
+        """Snapshots can be restored from the snapshot object"""
+        snapshot = models.Snapshot(
+            self.client, container=self.container,
+            name='an-snapshot')
+        snapshot.restore(wait=True)
 
 
 class TestFiles(testing.PyLXDTestCase):


### PR DESCRIPTION
This patchset adds restore methods to the Container and Snapshot classes
to make it possible to restore a snapshot without having to use the
raw_api in pylxd.

Closes: #353