### PR TITLE
Add live parameter for migrations

### DIFF
--- a/doc/source/containers.rst
+++ b/doc/source/containers.rst
@@ -68,7 +68,9 @@ Container methods
     an url to an interactive websocket and the execution only starts after a client connected to the websocket.
   - `migrate` - Migrate the container. The first argument is a client
     connection to the destination server. This call is asynchronous, so
-    `wait=True` is optional. The container on the new client is returned.
+    ``wait=True`` is optional. The container on the new client is returned.  If
+    ``live=True`` is passed to the function call, then the container is live
+    migrated (see the LXD documentation for further details).
   - `publish` - Publish the container as an image.  Note the container must be stopped
     in order to use this method.  If `wait=True` is passed, then the image is returned.
 
@@ -164,6 +166,12 @@ the source server has to be reachable by the destination server otherwise the mi
     cont.migrate(client_destination,wait=True)
 
 This will migrate the container from source server to destination server
+
+To migrate a live container, user the ``live=True`` parameter:
+
+..code-block:: python
+
+    cont.migrate(client__destination, live=True, wait=True)
 
 If you want an interactive shell in the container, you can attach to it via a websocket.
 

--- a/pylxd/tests/models/test_container.py
+++ b/pylxd/tests/models/test_container.py
@@ -285,7 +285,7 @@ class TestContainer(testing.PyLXDTestCase):
         from pylxd.client import Client
         from pylxd.exceptions import LXDAPIException
 
-        def generate_exception():
+        def generate_exception(*args, **kwargs):
             response = mock.Mock()
             response.status_code = 400
             raise LXDAPIException(response)
@@ -309,17 +309,18 @@ class TestContainer(testing.PyLXDTestCase):
             self.client, name='an-container')
         an_container.status_code = 103
 
-        def generate_exception():
+        def generate_exception(*args, **kwargs):
             response = mock.Mock()
             response.status_code = 103
             raise LXDAPIException(response)
 
         generate_migration_data.side_effect = generate_exception
 
-        an_migrated_container = an_container.migrate(client2)
+        an_migrated_container = an_container.migrate(client2, live=True)
 
         self.assertEqual('an-container', an_migrated_container.name)
         self.assertEqual(client2, an_migrated_container.client)
+        generate_migration_data.assert_called_once_with(True)
 
     def test_migrate_started(self):
         """A container is migrated."""


### PR DESCRIPTION
The LXD api provides a parameter to kick of live migrations.  See
https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-optional-targetmember-1
for further details.

Closes: #338
Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>