### PR TITLE
Fix dropped timeout in pylxd/client.py

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -85,7 +85,8 @@ class _APINode(object):
             name = 'storage-pools'
         return self.__class__('{}/{}'.format(self._api_endpoint, name),
                               cert=self.session.cert,
-                              verify=self.session.verify)
+                              verify=self.session.verify,
+                              timeout=self._timeout)
 
     def __getitem__(self, item):
         """This converts python api.thing[name] -> ".../thing/name"


### PR DESCRIPTION
When constructing the call, the [next-part] method creates the next
element in the chain of /part/<nextpart>.  However, it doesn't pass
through the timeout parameter which means that it doesn't end up on the
final call.  This patch fixes that.

Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>