### PR TITLE
Add PYLXD_WARNINGS env variable to be able to supress warnings

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -101,3 +101,19 @@ Some changes to LXD will return immediately, but actually occur in the
 background after the http response returns. All operations that happen
 this way will also take an optional `wait` parameter that, when `True`,
 will not return until the operation is completed.
+
+UserWarning: Attempted to set unknown attribute "x" on instance of "y"
+----------------------------------------------------------------------
+
+The LXD server changes frequently, particularly if it is snap installed.  In
+this case it is possible that the LXD server may send back objects with
+attributes that this version of pylxd is not aware of, and in that situation,
+the pylxd library issues the warning above.
+
+The default behaviour is that *one* warning is issued for each unknown
+attribute on *each* object class that it unknown.  Further warnings are then
+surpressed.  The environment variable ``PYLXD_WARNINGS`` can be set to control
+the warnings further:
+
+  - if set to ``none`` then *all* warnings are surpressed all the time.
+  - if set to ``always`` then warnings are always issued for each instance returned from the server.

--- a/pylxd/models/operation.py
+++ b/pylxd/models/operation.py
@@ -19,8 +19,21 @@ from pylxd import exceptions
 from six.moves.urllib import parse
 
 
+# Global used to record which warnings have been issues already for unknown
+# attributes.
+_seen_attribute_warnings = set()
+
+
 class Operation(object):
-    """A LXD operation."""
+    """An LXD operation.
+
+    If the LXD server sends attributes that this version of pylxd is unaware of
+    then a warning is printed.  By default the warning is issued ONCE and then
+    supressed for every subsequent attempted setting.  The warnings can be
+    completely suppressed by setting the environment variable PYLXD_WARNINGS to
+    'none', or always displayed by setting the PYLXD_WARNINGS variable to
+    'always'.
+    """
 
     __slots__ = [
         '_client',
@@ -53,6 +66,13 @@ class Operation(object):
             except AttributeError:
                 # ignore attributes we don't know about -- prevent breakage
                 # in the future if new attributes are added.
+                global _seen_attribute_warnings
+                env = os.environ.get('PYLXD_WARNINGS', '').lower()
+                if env != 'always' and key in _seen_attribute_warnings:
+                    continue
+                _seen_attribute_warnings.add(key)
+                if env == 'none':
+                    continue
                 warnings.warn(
                     'Attempted to set unknown attribute "{}" '
                     'on instance of "{}"'

--- a/pylxd/tests/models/test_operation.py
+++ b/pylxd/tests/models/test_operation.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import json
+import mock
 
 from pylxd import exceptions, models
 from pylxd.tests import testing
@@ -20,6 +21,36 @@ from pylxd.tests import testing
 
 class TestOperation(testing.PyLXDTestCase):
     """Tests for pylxd.models.Operation."""
+
+    @mock.patch.dict('os.environ', {'PYLXD_WARNINGS': ''})
+    @mock.patch('warnings.warn')
+    def test_init_warnings_once(self, mock_warn):
+        with mock.patch('pylxd.models.operation._seen_attribute_warnings',
+                        new=set()):
+            models.Operation(unknown='some_value')
+            mock_warn.assert_called_once_with(mock.ANY)
+            models.Operation(unknown='some_value_as_well')
+            mock_warn.assert_called_once_with(mock.ANY)
+            models.Operation(unknown2="some_2nd_value")
+            self.assertEqual(len(mock_warn.call_args_list), 2)
+
+    @mock.patch.dict('os.environ', {'PYLXD_WARNINGS': 'none'})
+    @mock.patch('warnings.warn')
+    def test_init_warnings_none(self, mock_warn):
+        with mock.patch('pylxd.models.operation._seen_attribute_warnings',
+                        new=set()):
+            models.Operation(unknown='some_value')
+            mock_warn.assert_not_called()
+
+    @mock.patch.dict('os.environ', {'PYLXD_WARNINGS': 'always'})
+    @mock.patch('warnings.warn')
+    def test_init_warnings_always(self, mock_warn):
+        with mock.patch('pylxd.models.operation._seen_attribute_warnings',
+                        new=set()):
+            models.Operation(unknown='some_value')
+            mock_warn.assert_called_once_with(mock.ANY)
+            models.Operation(unknown='some_value_as_well')
+            self.assertEqual(len(mock_warn.call_args_list), 2)
 
     def test_get(self):
         """Return an operation."""

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv =
    VIRTUAL_ENV={envdir}
+   PYLXD_WARNINGS=none
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = nosetests --with-coverage --cover-package=pylxd pylxd


### PR DESCRIPTION
If the LXD server that pylxd is connected to supports attributes on
objects that pylxd doesn't yet support, then a warning is issued using
the `warnings` module.  This can fill logs with annoying warnings.  So
this patch adds the ability to set an env variable PYLXD_WARNINGS to
'none' to suppress all the warnings, or to 'always' to get the existing
behaviour.  The new behavior is to issue a warning once for each
instance of an attribute that isn't known for each object.

Closes: #301
Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>