### PR TITLE
Fix change of behaviour on execute introduced in #363

### DIFF
--- a/pylxd/models/container.py
+++ b/pylxd/models/container.py
@@ -641,7 +641,7 @@ class _CommandWebsocketClient(WebSocketBaseClient):  # pragma: no cover
             self.last_message_empty = True
             if self.finish_off:
                 self.finished = True
-                return
+            return
         else:
             self.last_message_empty = False
         if message.encoding and self.message_encoding is None:


### PR DESCRIPTION
Essentially, the behavior changed for when a caller to the
container's execute method wished to handle the packets received back on
the websocket.  This change fixes the reversion.

Signed-off-by: Alex Kavanagh <alex.kavanagh@canonical.com>