### PR TITLE
Switch around detection of whether unix socket is snap or pkg

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -295,10 +295,10 @@ class Client(object):
         else:
             if 'LXD_DIR' in os.environ:
                 path = os.path.join(os.environ.get('LXD_DIR'), 'unix.socket')
-            elif os.path.exists('/var/lib/lxd/unix.socket'):
-                path = '/var/lib/lxd/unix.socket'
-            else:
+            elif os.path.exists('/var/snap/lxd/common/lxd/unix.socket'):
                 path = '/var/snap/lxd/common/lxd/unix.socket'
+            else:
+                path = '/var/lib/lxd/unix.socket'
             endpoint = 'http+unix://{}'.format(parse.quote(path, safe=''))
             self.api = _APINode(endpoint, timeout=timeout)
         self.api = self.api[version]
@@ -311,8 +311,8 @@ class Client(object):
             self.host_info = response.json()['metadata']
 
         except (requests.exceptions.ConnectionError,
-                requests.exceptions.InvalidURL):
-            raise exceptions.ClientConnectionFailed()
+                requests.exceptions.InvalidURL) as e:
+            raise exceptions.ClientConnectionFailed(str(e))
 
         self.cluster = managers.ClusterManager(self)
         self.certificates = managers.CertificateManager(self)

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -53,7 +53,7 @@ class TestClient(unittest.TestCase):
     @mock.patch('os.path.exists')
     def test_create(self, _path_exists):
         """Client creation sets default API endpoint."""
-        _path_exists.return_value = True
+        _path_exists.return_value = False
         expected = 'http+unix://%2Fvar%2Flib%2Flxd%2Funix.socket/1.0'
 
         an_client = client.Client()
@@ -64,7 +64,7 @@ class TestClient(unittest.TestCase):
     @mock.patch('os.environ')
     def test_create_with_snap_lxd(self, _environ, _path_exists):
         # """Client creation sets default API endpoint."""
-        _path_exists.return_value = False
+        _path_exists.return_value = True
         expected = ('http+unix://%2Fvar%2Fsnap%2Flxd%2F'
                     'common%2Flxd%2Funix.socket/1.0')
 


### PR DESCRIPTION
A previous change (which added LXD_DIR) switched around the detection of
whether LXD is installed as a snap or a package to "test for packaged
first".  Unfortunately, the LXD pkg leaves behind the unix socket after
it is uninstalled when the snap is installed on xenial and a lxd.migrate
command is issued.  This means that the detection code fails.  This
patch reverts the behaviour to look "test for snapped first".

This is reasonable as the only way that a both unix socket files could
exist is if the snapped version was added to a pkg version default
install (e.g. Xenial).  As running both isn't really a supported
scenario, the default of checking for the snap first is more likely to
work in most default scenarios.  The LXD_DIR environment variable is
still available if it needs overriding for the corner cases.

Fixes: #365