### PR TITLE
Add support for the resources endpoint.

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -322,10 +322,20 @@ class Client(object):
         self.operations = managers.OperationManager(self)
         self.profiles = managers.ProfileManager(self)
         self.storage_pools = managers.StoragePoolManager(self)
+        self._resource_cache = None
 
     @property
     def trusted(self):
         return self.host_info['auth'] == 'trusted'
+
+    @property
+    def resources(self):
+        if self._resource_cache is None:
+            response = self.api.resources.get()
+            if response.status_code != 200:
+                raise exceptions.ClientConnectionFailed()
+            self._resource_cache = response.json()['metadata']
+        return self._resource_cache
 
     def has_api_extension(self, name):
         """Return True if the `name` api extension exists.

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -331,6 +331,7 @@ class Client(object):
     @property
     def resources(self):
         if self._resource_cache is None:
+            self.assert_has_api_extension('resources')
             response = self.api.resources.get()
             if response.status_code != 200:
                 raise exceptions.ClientConnectionFailed()

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -280,6 +280,31 @@ class TestClient(unittest.TestCase):
             else:
                 self.assertEqual(expect_resource.query, actual_resource.query)
 
+    def test_resources(self):
+        a_client = client.Client()
+        response = mock.MagicMock(status_code=200)
+        response.json.return_value = {'metadata': {
+            'cpu': {},
+        }}
+        self.get.return_value = response
+        self.assertIn('cpu', a_client.resources)
+
+    def test_resources_raises_exception(self):
+        a_client = client.Client()
+        response = mock.MagicMock(status_code=400)
+        self.get.return_value = response
+        with self.assertRaises(exceptions.ClientConnectionFailed):
+            a_client.resources
+
+    def test_resources_uses_cache(self):
+        a_client = client.Client()
+        a_client._resource_cache = {'cpu': {}}
+        # Client.__init__ calls get, reset the mock before trying
+        # resources to confirm it wasn't called.
+        self.get.called = False
+        self.assertIn('cpu', a_client.resources)
+        self.assertFalse(self.get.called)
+
     def test_has_api_extension(self):
         a_client = client.Client()
         a_client.host_info = {'api_extensions': ["one", "two"]}

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -282,6 +282,7 @@ class TestClient(unittest.TestCase):
 
     def test_resources(self):
         a_client = client.Client()
+        a_client.host_info['api_extensions'] = ['resources']
         response = mock.MagicMock(status_code=200)
         response.json.return_value = {'metadata': {
             'cpu': {},
@@ -289,11 +290,18 @@ class TestClient(unittest.TestCase):
         self.get.return_value = response
         self.assertIn('cpu', a_client.resources)
 
-    def test_resources_raises_exception(self):
+    def test_resources_raises_conn_failed_exception(self):
         a_client = client.Client()
+        a_client.host_info['api_extensions'] = ['resources']
         response = mock.MagicMock(status_code=400)
         self.get.return_value = response
         with self.assertRaises(exceptions.ClientConnectionFailed):
+            a_client.resources
+
+    def test_resources_raises_api_extension_not_avail_exception(self):
+        a_client = client.Client()
+        a_client.host_info['api_extensions'] = []
+        with self.assertRaises(exceptions.LXDAPIExtensionNotAvailable):
             a_client.resources
 
     def test_resources_uses_cache(self):


### PR DESCRIPTION
The LXD resources endpoint returns hardware information about LXD host. This
data is retrieved only when called. The data is cached as it won't change.

Signed-off-by: Lee Trager <lee.trager@canonical.com>