### PR TITLE
Fix broken pipe error on xenial integration tests

### DIFF
--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -438,7 +438,10 @@ class Instance(model.Model):
 
             stdout.finish_soon()
             stderr.finish_soon()
-            manager.close_all()
+            try:
+                manager.close_all()
+            except BrokenPipeError:
+                pass
 
             while not stdout.finished or not stderr.finished:
                 time.sleep(.1)  # progma: no cover


### PR DESCRIPTION
It appears that the manager.close_all() can cause a broken pipe
error.  At this stage, that means that the pipe is closed and thus
it's actually okay to just continue and ignore the error (as per stdin)

Fixes: #379