### PR TITLE
Make the websocket client reuse the client's certificate

### DIFF
--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -338,7 +338,6 @@ class Client:
         """
 
         self.project = project
-        self.cert = cert
         if endpoint:
             if endpoint.startswith("/") and os.path.exists(endpoint):
                 endpoint = "http+unix://{}".format(parse.quote(endpoint, safe=""))
@@ -361,6 +360,7 @@ class Client:
         api = _APINode(
             endpoint, cert=cert, verify=verify, timeout=timeout, project=project
         )
+        self.cert = cert
         self.api = api[version]
 
         # Verify the connection is valid.
@@ -483,7 +483,11 @@ class Client:
         if websocket_client is None:
             websocket_client = _WebsocketClient
 
-        client = websocket_client(self.websocket_url)
+        use_ssl = self.api.scheme == "https" and self.cert
+        ssl_options = (
+            {"certfile": self.cert[0], "keyfile": self.cert[1]} if use_ssl else None
+        )
+        client = websocket_client(self.websocket_url, ssl_options=ssl_options)
         parsed = parse.urlparse(self.api.events._api_endpoint)
 
         resource = parsed.path

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -304,7 +304,9 @@ class TestClient(TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with("ws+unix:///lxd/unix.socket")
+        WebsocketClient.assert_called_once_with(
+            "ws+unix:///lxd/unix.socket", ssl_options=None
+        )
 
     def test_events_htt(self):
         """An http compatible websocket client is returned."""
@@ -315,18 +317,23 @@ class TestClient(TestCase):
 
         an_client.events(websocket_client=WebsocketClient)
 
-        WebsocketClient.assert_called_once_with("ws://lxd.local")
+        WebsocketClient.assert_called_once_with("ws://lxd.local", ssl_options=None)
 
     def test_events_https(self):
         """An https compatible websocket client is returned."""
         websocket_client = mock.Mock(resource=None)
         WebsocketClient = mock.Mock()
         WebsocketClient.return_value = websocket_client
-        an_client = client.Client("https://lxd.local")
+        an_client = client.Client("https://lxd.local", cert=client.DEFAULT_CERTS)
 
         an_client.events(websocket_client=WebsocketClient)
-
-        WebsocketClient.assert_called_once_with("wss://lxd.local")
+        ssl_options = {
+            "certfile": client.DEFAULT_CERTS.cert,
+            "keyfile": client.DEFAULT_CERTS.key,
+        }
+        WebsocketClient.assert_called_once_with(
+            "wss://lxd.local", ssl_options=ssl_options
+        )
 
     def test_events_type_filter(self):
         """The websocket client can filter events by type."""


### PR DESCRIPTION
This change allows to use the `events()` on remote clients, by passing the SSL certificate and keyfile from the HTTP client to to the websocket client.

I had to move the definition of `self.cert` to pick up the default certificates.

This fixes issue #381.