### PR TITLE
Bump release number for next cycle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = pylxd
 summary = python library for lxd
-version = 2.2.11
+version = 2.2.12
 description-file =
     README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)


### PR DESCRIPTION
This bumps the release number to 2.2.12 so that development
can continue.  Note the next release doesn't actually need to be 2.2.12.