### PR TITLE
test_networks: Avoid triggering volatile.bridge.hwaddr

### DIFF
--- a/integration/test_networks.py
+++ b/integration/test_networks.py
@@ -63,6 +63,7 @@ class TestNetworks(NetworkTestCase):
         kwargs = {
             'name': 'eth10',
             'config': {
+                'bridge.hwaddr': '00:16:3e:12:34:56',
                 'ipv4.address': '10.10.10.1/24',
                 'ipv4.nat': 'true',
                 'ipv6.address': 'none',


### PR DESCRIPTION
LXD now generates a stable MAC address for networks.
This is placed in volatile.bridge.hwaddr unless the network has a
pre-configured address.

This makes the current network test fail as it assumes that the config
returned after creation will be identical to that provided during
creation.

There are two ways of fixing this:

 - Strip all volatile keys
 - Provide a pre-set bridge.hwaddr key

This implements the latter.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>