### PR TITLE
client: Add basic support for projects

### DIFF
--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -22,8 +22,11 @@ openssl req -new -x509 -nodes -sha1 -days 365 \
         -key "$config_dir/client.key" -out "$config_dir/client.crt" \
         -subj="/C=UK/ST=London/L=London/O=OrgName/OU=Test/CN=example.com"
 
-lxc storage create default dir
-lxc profile device add default root disk path=/ pool=default
+
+if ! lxc storage show default ; then
+    lxc storage create default dir
+    lxc profile device add default root disk path=/ pool=default
+fi
 
 # finally run the integration tests
 tox -e integration

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -35,16 +35,15 @@ class TestClient(IntegrationTestCase):
         self.assertTrue(client.trusted)
 
     def test_authenticate_with_project(self):
-
-        client = pylxd.Client(
-            "https://127.0.0.1:8443/", verify=False, project="test-project"
-        )
+        try:
+            client = pylxd.Client(
+                "https://127.0.0.1:8443/", verify=False, project="test-project"
+            )
+        except exceptions.ClientConnectionFailed as e:
+            message = str(e)
+            if message == "Remote server doesn't handle projects":
+                self.skipTest(message)
+            raise
 
         client.authenticate("password")
-
-        try:
-            self.assertEqual(client.host_info["environment"]["project"], "test-project")
-        except exceptions.ClientConnectionFailed as e:
-            if e.message == "Remote server doesn't handle projects":
-                self.skipTest(e.message)
-            raise
+        self.assertEqual(client.host_info["environment"]["project"], "test-project")

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -24,8 +25,6 @@ class TestClient(IntegrationTestCase):
     """Tests for `Client`."""
 
     def test_authenticate(self):
-        # This is another test with multiple assertions, as it is a test of
-        # flow, rather than a single source of functionality.
         client = pylxd.Client("https://127.0.0.1:8443/", verify=False)
 
         self.assertFalse(client.trusted)
@@ -33,3 +32,12 @@ class TestClient(IntegrationTestCase):
         client.authenticate("password")
 
         self.assertTrue(client.trusted)
+
+    def test_authenticate_with_project(self):
+
+        client = pylxd.Client(
+            "https://127.0.0.1:8443/", verify=False, project="test-project"
+        )
+
+        client.authenticate("password")
+        self.assertEqual(client.host_info["environment"]["project"], "test-project")

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -16,6 +16,7 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 import pylxd
+from pylxd import exceptions
 from integration.testing import IntegrationTestCase
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
@@ -40,4 +41,10 @@ class TestClient(IntegrationTestCase):
         )
 
         client.authenticate("password")
-        self.assertEqual(client.host_info["environment"]["project"], "test-project")
+
+        try:
+            self.assertEqual(client.host_info["environment"]["project"], "test-project")
+        except exceptions.ClientConnectionFailed as e:
+            if e.message == "Remote server doesn't handle projects":
+                self.skipTest(e.message)
+            raise

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -16,8 +16,8 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 import pylxd
-from pylxd import exceptions
 from integration.testing import IntegrationTestCase
+from pylxd import exceptions
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,16 +11,16 @@ setenv =
    PYLXD_WARNINGS=none
 deps =
    -r{toxinidir}/test-requirements.txt
-commands = pytest --cov=pylxd pylxd
+commands = pytest --cov=pylxd pylxd {posargs}
 
 [testenv:integration]
-commands = pytest integration
+commands = pytest integration {posargs}
 
 [testenv:integration-in-lxd]
 commands = {toxinidir}/integration/run-integration-tests-in-lxd
 
 [testenv:migration]
-commands = pytest migration
+commands = pytest migration {posargs}
 
 [testenv:format]
 basepython=python3


### PR DESCRIPTION
This allows passing the project name as a string to Client and have it
automatically added to all URLs.

Blackened by @d0ugal for easier merging.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>
Signed-off-by: Dougal Matthews <dougal@dougalmatthews.com>