### PR TITLE
Correct a typo in the integration test

### DIFF
--- a/integration/test_projects.py
+++ b/integration/test_projects.py
@@ -65,7 +65,7 @@ class TestProjects(BaseTestProject):
         self.assertEqual(name, project.name)
         self.assertEqual(description, project.description)
         for key, value in config.items():
-            self.assertEqual(config[key], value)
+            self.assertEqual(project.config[key], value)
 
 
 class TestProject(BaseTestProject):


### PR DESCRIPTION
I think we can be confident that Pythons dict implementation is correct.