### PR TITLE
Remove broken/defunct pypy from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py3,pypy,lint
+envlist = py3,lint
 skipsdist = True
 
 [testenv]
@@ -48,4 +48,4 @@ commands=
 show-source = True
 ignore = E203, E266, E501, W503, W504
 builtins = _
-exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build
+exclude=.venv,.git,.tox,dist,doc,*egg,build


### PR DESCRIPTION
Drive-by clean up lint exclude.

Signed-off-by: Adam Collard <adam.collard@canonical.com>