### PR TITLE
Add location to operation model

### DIFF
--- a/pylxd/models/operation.py
+++ b/pylxd/models/operation.py
@@ -41,6 +41,7 @@ class Operation:
         "description",
         "err",
         "id",
+        "location",
         "may_cancel",
         "metadata",
         "resources",


### PR DESCRIPTION
This commit aims to fix a warning when using the operation model api on a
recent LXD version.
https://github.com/lxc/lxd/commit/55fcda838f549203d4cd52d19eb9166b0ed31945
introduced the `location` field to the operations model.

Signed-off-by: David Negreira <david.negreira@canonical.com>