### PR TITLE
add tox target to typecheck via mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,25 @@ jobs:
     - name: Lint shell files
       uses: ludeeus/action-shellcheck@master
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.6"
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip tox
+
+    - name: Typecheck Python files
+      run: |
+        tox -e check
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/pylxd/deprecated/tests/test_certificate.py
+++ b/pylxd/deprecated/tests/test_certificate.py
@@ -13,8 +13,8 @@
 #    under the License.
 
 import json
+from unittest import mock
 
-import mock
 from ddt import ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/deprecated/tests/test_connection.py
+++ b/pylxd/deprecated/tests/test_connection.py
@@ -14,11 +14,10 @@
 
 import inspect
 import socket
-import unittest
 from http import client as http_client
 from io import BytesIO
+from unittest import TestCase, mock
 
-import mock
 from ddt import ddt
 
 from pylxd.deprecated import connection, exceptions
@@ -26,7 +25,7 @@ from pylxd.deprecated.tests import annotated_data
 
 
 @ddt
-class LXDInitConnectionTest(unittest.TestCase):
+class LXDInitConnectionTest(TestCase):
     @mock.patch("socket.socket")
     @mock.patch.object(http_client.HTTPConnection, "__init__")
     def test_http_connection(self, mc, ms):
@@ -100,7 +99,7 @@ class FakeResponse:
 
 @ddt
 @mock.patch("pylxd.deprecated.connection.LXDConnection.get_connection")
-class LXDConnectionTest(unittest.TestCase):
+class LXDConnectionTest(TestCase):
     def setUp(self):
         super().setUp()
         self.conn = connection.LXDConnection()

--- a/pylxd/deprecated/tests/test_container.py
+++ b/pylxd/deprecated/tests/test_container.py
@@ -15,8 +15,8 @@
 import json
 import tempfile
 from collections import OrderedDict
+from unittest import mock
 
-import mock
 from ddt import ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/deprecated/tests/test_host.py
+++ b/pylxd/deprecated/tests/test_host.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 from ddt import data, ddt
 
 from pylxd.deprecated import connection, exceptions

--- a/pylxd/deprecated/tests/test_image.py
+++ b/pylxd/deprecated/tests/test_image.py
@@ -14,10 +14,9 @@
 
 import builtins
 import datetime
-import unittest
 from io import StringIO
+from unittest import TestCase, mock
 
-import mock
 from ddt import ddt
 
 from pylxd.deprecated import connection, exceptions, image
@@ -198,7 +197,7 @@ class LXDAPIImageTestRaw(LXDAPITestBase):
     "get_object",
     return_value=(200, fake_api.fake_image_info()),
 )
-class LXDAPIImageInfoTest(unittest.TestCase):
+class LXDAPIImageInfoTest(TestCase):
     def setUp(self):
         super().setUp()
         self.image = image.LXDImage()

--- a/pylxd/deprecated/tests/test_image_alias.py
+++ b/pylxd/deprecated/tests/test_image_alias.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 from ddt import data, ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/deprecated/tests/test_network.py
+++ b/pylxd/deprecated/tests/test_network.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 from ddt import ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/deprecated/tests/test_operation.py
+++ b/pylxd/deprecated/tests/test_operation.py
@@ -13,8 +13,8 @@
 #    under the License.
 
 import datetime
+from unittest import mock
 
-import mock
 from ddt import ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/deprecated/tests/test_profiles.py
+++ b/pylxd/deprecated/tests/test_profiles.py
@@ -12,7 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 from ddt import data, ddt
 
 from pylxd.deprecated import connection

--- a/pylxd/tests/models/test_instance.py
+++ b/pylxd/tests/models/test_instance.py
@@ -3,9 +3,9 @@ import json
 import os
 import shutil
 import tempfile
+from unittest import mock
 from urllib.parse import quote as url_quote
 
-import mock
 import requests
 
 from pylxd import exceptions, models

--- a/pylxd/tests/models/test_network.py
+++ b/pylxd/tests/models/test_network.py
@@ -11,12 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import json
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import json
+from unittest import mock
 
 from pylxd import exceptions, models
 from pylxd.exceptions import LXDAPIExtensionNotAvailable

--- a/pylxd/tests/models/test_operation.py
+++ b/pylxd/tests/models/test_operation.py
@@ -13,8 +13,7 @@
 #    under the License.
 
 import json
-
-import mock
+from unittest import mock
 
 from pylxd import exceptions, models
 from pylxd.tests import testing

--- a/pylxd/tests/models/test_storage.py
+++ b/pylxd/tests/models/test_storage.py
@@ -11,12 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import json
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import json
+from unittest import mock
 
 from pylxd import exceptions, models
 from pylxd.tests import testing

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -14,10 +14,9 @@
 import json
 import os
 import os.path
-import unittest
+from unittest import TestCase, mock
 from urllib import parse
 
-import mock
 import pytest
 import requests
 import requests_unixsocket
@@ -26,7 +25,7 @@ from pylxd import client, exceptions
 from pylxd.tests.testing import requires_ws4py
 
 
-class TestClient(unittest.TestCase):
+class TestClient(TestCase):
     """Tests for pylxd.client.Client."""
 
     def setUp(self):
@@ -421,7 +420,7 @@ class TestClient(unittest.TestCase):
         a_client.assert_has_api_extension("two")
 
 
-class TestAPINode(unittest.TestCase):
+class TestAPINode(TestCase):
     """Tests for pylxd.client._APINode."""
 
     def test_getattr(self):
@@ -568,7 +567,7 @@ class TestAPINode(unittest.TestCase):
         session.delete.assert_called_once_with("http://test.com", timeout=None)
 
 
-class TestWebsocketClient(unittest.TestCase):
+class TestWebsocketClient(TestCase):
     """Tests for pylxd.client.WebsocketClient."""
 
     @requires_ws4py

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,12 @@ lint_files =
     {toxinidir}/pylxd
     {toxinidir}/setup.py
 
+[mypy]
+incremental = False
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True
+
 [build_sphinx]
 source-dir = doc/source
 build-dir = doc/build

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,11 @@ commands=
   isort --profile black --check-only --diff {toxinidir}
   flake8 {toxinidir}
 
+[testenv:check]
+deps =
+  mypy
+commands =
+  mypy -p pylxd {posargs}
 
 [flake8]
 show-source = True


### PR DESCRIPTION
The plan is to start adding type checks and verify them via mypy.

Also cleanup a bunch of mocck imports to import via unittest module.

Signed-off-by: Alberto Donato <alberto.donato@canonical.com>