### PR TITLE
Fix names of namedtuples to match variable names

### DIFF
--- a/pylxd/deprecated/connection.py
+++ b/pylxd/deprecated/connection.py
@@ -76,7 +76,7 @@ class HTTPSConnection(http_client.HTTPConnection):
         )
 
 
-_LXDResponse = namedtuple("LXDResponse", ["status", "body", "json"])
+_LXDResponse = namedtuple("_LXDResponse", ["status", "body", "json"])
 
 
 if websocket is not None:

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -39,7 +39,7 @@ class InstanceState(model.AttributeDict):
 
 
 _InstanceExecuteResult = collections.namedtuple(
-    "InstanceExecuteResult", ["exit_code", "stdout", "stderr"]
+    "_InstanceExecuteResult", ["exit_code", "stdout", "stderr"]
 )
 
 


### PR DESCRIPTION
https://mypy-lang.blogspot.com/2021/01/mypy-0800-released.html

MyPy 0.800 includes a check for the variable name of `namedtuple` to match the given name.

Signed-off-by: Adam Collard <adam.collard@canonical.com>