### PR TITLE
Bump version to 2.3.1a

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pylxd
-version = 2.3.0
+version = 2.3.1a
 description = python library for LXD
 long_description = file: README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)
@@ -41,7 +41,7 @@ format =
     black == 20.8b1
     flake8 >= 2.5.0
     isort == 5.6.4
-check:
+check =
     mypy
 doc =
     Sphinx


### PR DESCRIPTION
Drive-by unify syntax in setup.cfg for check.

Signed-off-by: Adam Collard <adam.collard@canonical.com>