### PR TITLE
cleanup ws4py and tox setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,5 @@ jobs:
 
     - name: Test
       run: |
-        tox -e py
+        tox -e coverage
         codecov

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -78,7 +78,7 @@ Testing
 Testing pyLXD is in 3 parts:
 
 1. Conformance with Black and isort, using the ``tox -e lint`` command.
-2. Unit tests using ``tox -e py``.
+2. Unit tests using ``tox -e py`` or ``tox -e coverage``.
 3. Integration tests using the ``tox -e integration-in-lxd``.
 
 .. note:: all of the tests can be run by just using the ``tox`` command on it's

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -20,14 +20,7 @@ from urllib import parse
 
 import requests
 import requests_unixsocket
-
-try:
-    from ws4py.client import WebSocketBaseClient
-
-    _ws4py_installed = True
-except ImportError:  # pragma: no cover
-    WebSocketBaseClient = object
-    _ws4py_installed = False
+from ws4py.client import WebSocketBaseClient
 
 from pylxd import exceptions, managers
 
@@ -487,8 +480,6 @@ class Client:
         :returns: instance of the websocket client
         :rtype: Option[_WebsocketClient(), :param:`websocket_client`]
         """
-        if not _ws4py_installed:
-            raise ValueError("This feature requires the optional ws4py library.")
         if websocket_client is None:
             websocket_client = _WebsocketClient
 

--- a/pylxd/deprecated/connection.py
+++ b/pylxd/deprecated/connection.py
@@ -23,18 +23,11 @@ import threading
 from http import client as http_client
 from typing import Any, NamedTuple
 
-try:
-    from ws4py import client as websocket
-except ImportError:
-    websocket = None
+from ws4py.client import WebSocketBaseClient
 
 from pylxd.deprecated import exceptions, utils
 
-# For Python >= 2.7.9 and Python 3.x
-if hasattr(ssl, "PROTOCOL_TLSv1_2"):
-    DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
-else:
-    DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1
+DEFAULT_TLS_VERSION = ssl.PROTOCOL_TLSv1_2
 
 
 class UnixHTTPConnection(http_client.HTTPConnection):
@@ -83,50 +76,48 @@ class _LXDResponse(NamedTuple):
     json: Any
 
 
-if websocket is not None:
+class WebSocketClient(WebSocketBaseClient):
+    def __init__(
+        self, url, protocols=None, extensions=None, ssl_options=None, headers=None
+    ):
+        """WebSocket client that executes into a eventlet green thread."""
+        WebSocketBaseClient.__init__(
+            self,
+            url,
+            protocols,
+            extensions,
+            ssl_options=ssl_options,
+            headers=headers,
+        )
+        self._th = threading.Thread(target=self.run, name="WebSocketClient")
+        self._th.daemon = True
 
-    class WebSocketClient(websocket.WebSocketBaseClient):
-        def __init__(
-            self, url, protocols=None, extensions=None, ssl_options=None, headers=None
-        ):
-            """WebSocket client that executes into a eventlet green thread."""
-            websocket.WebSocketBaseClient.__init__(
-                self,
-                url,
-                protocols,
-                extensions,
-                ssl_options=ssl_options,
-                headers=headers,
-            )
-            self._th = threading.Thread(target=self.run, name="WebSocketClient")
-            self._th.daemon = True
+        self.messages = queue.Queue()
 
-            self.messages = queue.Queue()
+    def handshake_ok(self):
+        """Starts the client's thread."""
+        self._th.start()
 
-        def handshake_ok(self):
-            """Starts the client's thread."""
-            self._th.start()
+    def received_message(self, message):
+        """Override the base class to store the incoming message."""
+        self.messages.put(copy.deepcopy(message))
 
-        def received_message(self, message):
-            """Override the base class to store the incoming message."""
-            self.messages.put(copy.deepcopy(message))
+    def closed(self, code, reason=None):
+        # When the connection is closed, put a StopIteration
+        # on the message queue to signal there's nothing left
+        # to wait for
+        self.messages.put(StopIteration)
 
-        def closed(self, code, reason=None):
-            # When the connection is closed, put a StopIteration
-            # on the message queue to signal there's nothing left
-            # to wait for
-            self.messages.put(StopIteration)
-
-        def receive(self):
-            # If the websocket was terminated and there are no messages
-            # left in the queue, return None immediately otherwise the client
-            # will block forever
-            if self.terminated and self.messages.empty():
-                return None
-            message = self.messages.get()
-            if message is StopIteration:
-                return None
-            return message
+    def receive(self):
+        # If the websocket was terminated and there are no messages
+        # left in the queue, return None immediately otherwise the client
+        # will block forever
+        if self.terminated and self.messages.empty():
+            return None
+        message = self.messages.get()
+        if message is StopIteration:
+            return None
+        return message
 
 
 class LXDConnection:
@@ -199,8 +190,6 @@ class LXDConnection:
             raise exceptions.PyLXDException("Failed to get raw response")
 
     def get_ws(self, path):
-        if websocket is None:
-            raise ValueError("This feature requires the optional ws4py library.")
         if self.unix_socket:
             connection_string = "ws+unix://%s" % self.unix_socket
         else:

--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -18,15 +18,9 @@ import time
 from typing import IO, NamedTuple
 from urllib import parse
 
-try:
-    from ws4py.client import WebSocketBaseClient
-    from ws4py.manager import WebSocketManager
-    from ws4py.messaging import BinaryMessage
-
-    _ws4py_installed = True
-except ImportError:  # pragma: no cover
-    WebSocketBaseClient = object
-    _ws4py_installed = False
+from ws4py.client import WebSocketBaseClient
+from ws4py.manager import WebSocketManager
+from ws4py.messaging import BinaryMessage
 
 from pylxd import managers
 from pylxd.exceptions import LXDAPIException
@@ -422,12 +416,9 @@ class Instance(model.Model):
         :type group: int
         :param cwd: Current working directory
         :type cwd: str
-        :raises ValueError: if the ws4py library is not installed.
         :returns: A tuple of `(exit_code, stdout, stderr)`
         :rtype: _InstanceExecuteResult() namedtuple
         """
-        if not _ws4py_installed:
-            raise ValueError("This feature requires the optional ws4py library.")
         if isinstance(commands, str):
             raise TypeError("First argument must be a list.")
         if environment is None:

--- a/pylxd/tests/models/test_instance.py
+++ b/pylxd/tests/models/test_instance.py
@@ -204,7 +204,6 @@ class TestInstance(testing.PyLXDTestCase):
 
         an_instance.delete(wait=True)
 
-    @testing.requires_ws4py
     @mock.patch("pylxd.models.instance._StdinWebsocket")
     @mock.patch("pylxd.models.instance._CommandWebsocketClient")
     def test_execute(self, _CommandWebsocketClient, _StdinWebsocket):
@@ -221,7 +220,6 @@ class TestInstance(testing.PyLXDTestCase):
         self.assertEqual(0, result.exit_code)
         self.assertEqual("test\n", result.stdout)
 
-    @testing.requires_ws4py
     @mock.patch("pylxd.models.instance._StdinWebsocket")
     @mock.patch("pylxd.models.instance._CommandWebsocketClient")
     def test_execute_with_env(self, _CommandWebsocketClient, _StdinWebsocket):
@@ -238,23 +236,6 @@ class TestInstance(testing.PyLXDTestCase):
         self.assertEqual(0, result.exit_code)
         self.assertEqual("test\n", result.stdout)
 
-    def test_execute_no_ws4py(self):
-        """If ws4py is not installed, ValueError is raised."""
-        from pylxd.models import instance
-
-        old_installed = instance._ws4py_installed
-        instance._ws4py_installed = False
-
-        def cleanup():
-            instance._ws4py_installed = old_installed
-
-        self.addCleanup(cleanup)
-
-        an_instance = models.Instance(self.client, name="an-instance")
-
-        self.assertRaises(ValueError, an_instance.execute, ["echo", "test"])
-
-    @testing.requires_ws4py
     def test_execute_string(self):
         """A command passed as string raises a TypeError."""
         an_instance = models.Instance(self.client, name="an-instance")

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -22,7 +22,6 @@ import requests
 import requests_unixsocket
 
 from pylxd import client, exceptions
-from pylxd.tests.testing import requires_ws4py
 
 
 class TestClient(TestCase):
@@ -287,7 +286,6 @@ class TestClient(TestCase):
         an_client = client.Client()
         self.assertEqual("zfs", an_client.host_info["environment"]["storage"])
 
-    @requires_ws4py
     def test_events(self):
         """The default websocket client is returned."""
         an_client = client.Client()
@@ -296,24 +294,6 @@ class TestClient(TestCase):
 
         self.assertEqual("/1.0/events", ws_client.resource)
 
-    def test_events_no_ws4py(self):
-        """No ws4py will result in a ValueError."""
-        from pylxd import client
-
-        old_installed = client._ws4py_installed
-        client._ws4py_installed = False
-
-        def cleanup():
-            client._ws4py_installed = old_installed
-
-        self.addCleanup(cleanup)
-
-        an_client = client.Client()
-
-        self.assertRaises(ValueError, an_client.events)
-        client._ws4py_installed
-
-    @requires_ws4py
     def test_events_unix_socket(self):
         """A unix socket compatible websocket client is returned."""
         websocket_client = mock.Mock(resource=None)
@@ -326,7 +306,6 @@ class TestClient(TestCase):
 
         WebsocketClient.assert_called_once_with("ws+unix:///lxd/unix.socket")
 
-    @requires_ws4py
     def test_events_htt(self):
         """An http compatible websocket client is returned."""
         websocket_client = mock.Mock(resource=None)
@@ -338,7 +317,6 @@ class TestClient(TestCase):
 
         WebsocketClient.assert_called_once_with("ws://lxd.local")
 
-    @requires_ws4py
     def test_events_https(self):
         """An https compatible websocket client is returned."""
         websocket_client = mock.Mock(resource=None)
@@ -350,7 +328,6 @@ class TestClient(TestCase):
 
         WebsocketClient.assert_called_once_with("wss://lxd.local")
 
-    @requires_ws4py
     def test_events_type_filter(self):
         """The websocket client can filter events by type."""
 
@@ -592,14 +569,12 @@ class TestAPINode(TestCase):
 class TestWebsocketClient(TestCase):
     """Tests for pylxd.client.WebsocketClient."""
 
-    @requires_ws4py
     def test_handshake_ok(self):
         """A `message` attribute of an empty list is created."""
         ws_client = client._WebsocketClient("ws://an/fake/path")
         ws_client.handshake_ok()
         self.assertEqual([], ws_client.messages)
 
-    @requires_ws4py
     def test_received_message(self):
         """A json dict is added to the messages attribute."""
         message = mock.Mock(data=json.dumps({"test": "data"}).encode("utf-8"))

--- a/pylxd/tests/testing.py
+++ b/pylxd/tests/testing.py
@@ -6,21 +6,6 @@ from pylxd.client import Client
 from pylxd.tests import mock_lxd
 
 
-def requires_ws4py(f):
-    """Marks a test as requiring ws4py.
-
-    As ws4py is an optional dependency, some tests should
-    be skipped, as they won't run properly if ws4py is not
-    installed.
-    """
-    try:
-        import ws4py  # NOQA
-
-        return f
-    except ImportError:
-        return unittest.skip("ws4py is not installed")(f)
-
-
 class PyLXDTestCase(unittest.TestCase):
     """A test case for handling mocking of LXD services."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,13 +73,12 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -U {opts} {packages}
 setenv =
-    VIRTUAL_ENV={envdir}
     PYLXD_WARNINGS=none
 deps =
     .[testing]
-commands = pytest --cov=pylxd pylxd {posargs}
+commands =
+    pytest {posargs:pylxd}
 
 [testenv:integration]
 commands =
@@ -112,6 +111,11 @@ deps =
     .[check]
 commands =
     mypy -p pylxd {posargs}
+
+[testenv:coverage]
+deps =
+    .[testing]
+commands = pytest --cov=pylxd pylxd {posargs}
 
 [testenv:i18n]
 deps =


### PR DESCRIPTION
ws4py is a required dependency, no need to check for it

This also splits the `coverage` and `py` tox targets so that's possible to use the latter to run a subset of tests