### PR TITLE
Add projects and restricted attributes to certificates

### DIFF
--- a/pylxd/models/certificate.py
+++ b/pylxd/models/certificate.py
@@ -28,6 +28,8 @@ class Certificate(model.Model):
     fingerprint = model.Attribute()
     type = model.Attribute()
     name = model.Attribute()
+    projects = model.Attribute()
+    restricted = model.Attribute()
 
     @classmethod
     def get(cls, client, fingerprint):


### PR DESCRIPTION
This silences warning about unknown attributes:

```
>>> import pylxd
>>> client = pylxd.Client()
>>> c = client.certificates.get('502cdfa1d3e2')
/usr/local/lib/python3.8/dist-packages/pylxd/models/_model.py:146: UserWarning: Attempted to set unknown attribute "restricted" on instance of "Certificate"
  warnings.warn(
/usr/local/lib/python3.8/dist-packages/pylxd/models/_model.py:146: UserWarning: Attempted to set unknown attribute "projects" on instance of "Certificate"
  warnings.warn(
>>> 
```