### PR TITLE
bump version to 2.3.2a

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pylxd
-version = 2.3.1
+version = 2.3.2a
 description = python library for LXD
 long_description = file: README.rst
 author = Paul Hummer and others (see CONTRIBUTORS.rst)


### PR DESCRIPTION
Signed-off-by: Alberto Donato <alberto.donato@canonical.com>