### PR TITLE
integration: Skip cluster test when standalone

### DIFF
--- a/integration/test_cluster_members.py
+++ b/integration/test_cluster_members.py
@@ -22,6 +22,9 @@ class ClusterMemberTestCase(IntegrationTestCase):
         if not self.client.has_api_extension("clustering"):
             self.skipTest("Required LXD API extension not available!")
 
+        if not self.client.server_clustered:
+            self.skipTest("Server isn't part of a cluster!")
+
 
 class TestClusterMembers(ClusterMemberTestCase):
     """Tests for `Client.cluster_members.`"""


### PR DESCRIPTION
For some reason the PyLXD tests were expecting LXD to return valid
responses on the cluster API for standalone systems.

As LXD has now fixed this issue and is correctly returning the "Not clustered"
error for all those endpoints, the tests are now breaking.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>