### PR TITLE
Improve TLS doc

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -10,10 +10,10 @@ instance's "trust password".
 Generate a certificate
 ======================
 
-To generate a keypair, you should use the `openssl` command. As an example::
+To generate a keypair, you should use the `openssl` command. As an example:
 
-    openssl req -newkey rsa:2048 -nodes -keyout lxd.key -out lxd.csr
-    openssl x509 -signkey lxd.key -in lxd.csr -req -days 365 -out lxd.crt
+.. code-block:: console
+    openssl req -x509 -newkey rsa:2048 -keyout lxd.key -nodes -out lxd.crt -subj "/CN=lxd.local"
 
 For more detail on the commands, or to customize the keys, please see the
 documentation for the `openssl` command.

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -17,17 +17,28 @@ localhost:
     >>> client = Client()
 
 If your LXD instance is listening on HTTPS, you can pass a two part tuple
-of (cert, key) as the `cert` argument.
+of (cert, key) as the `cert` argument and a PEM file containing the LXD's
+certificate to the `verify` argument:
 
 .. code-block:: python
 
     >>> from pylxd import Client
     >>> client = Client(
     ...     endpoint='http://10.0.0.1:8443',
-    ...     cert=('/path/to/client.crt', '/path/to/client.key'))
+    ...     cert=('/path/to/client.crt', '/path/to/client.key'),
+    ...     verify='/path/to/server.crt')
 
-Note: in the case where the certificate is self signed (LXD default),
-you may need to pass `verify=False`.
+In the case where the certificate is self-signed (LXD's default), you may
+opt to disable the TLS fingerprint verification with `verify=False`. As this
+disables an important security feature, doing so is strongly discouraged.
+
+.. code-block:: python
+
+    >>> from pylxd import Client
+    >>> client = Client(
+    ...     endpoint='http://10.0.0.1:8443',
+    ...     cert=('/path/to/client.crt', '/path/to/client.key'),
+    ...     verify=False)
 
 If LXD is configured to use projects and you would like to interact with a
 specific one, you can specify its name as the `project` argument.


### PR DESCRIPTION
Document how TLS fingerprint verification should be used, inspired by https://discuss.linuxcontainers.org/t/pylxd-certificate-verify-failed-self-signed-certificate/13232

While at it, simplify the self-signed client cert generation example to be easily copy-n-pasted.