### PR TITLE
github-action: auto create release on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,19 @@ jobs:
       run: |
         tox -e coverage
         codecov
+
+
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      if: startsWith(github.event.ref, 'refs/tags')
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Release ${{ github.ref }}
+        generateReleaseNotes: true


### PR DESCRIPTION
Signed-off-by: fliiiix <hi@l33t.name>

Because of this issue [here](https://github.com/lxc/pylxd/issues/500) i thought it would be nice it the github action keeps the tags and github release in sync. 
(A bit hard to test but i used it like this in other repos)