### PR TITLE
Misc fixes

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -31,6 +31,8 @@ certificate to the `verify` argument:
 In the case where the certificate is self-signed (LXD's default), you may
 opt to disable the TLS fingerprint verification with `verify=False`. As this
 disables an important security feature, doing so is strongly discouraged.
+The client filesystem will be searched for potential certificate to use
+for TLS verification.
 
 .. code-block:: python
 

--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 sudo apt update
-sudo apt install -y \
+sudo apt install -y --no-install-recommends \
      build-essential \
      busybox-static \
      libffi-dev \

--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -17,5 +17,11 @@ if ! lxc storage show default >/dev/null 2>&1; then
     lxc profile device add default root disk path=/ pool=default
 fi
 
+# Save a copy of the server cert for verification by pylxd client using "https://127.0.0.1:8443"
+if [ -e /var/snap/lxd/common/lxd/server.crt ]; then
+    mkdir -p ~/snap/lxd/common/config/servercerts
+    cp /var/snap/lxd/common/lxd/server.crt ~/snap/lxd/common/config/servercerts/127.0.0.1.crt
+fi
+
 # finally run the integration tests
 tox -e integration

--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-sudo apt update
-sudo apt install -y --no-install-recommends \
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
      build-essential \
      busybox-static \
      libffi-dev \

--- a/integration/run-integration-tests
+++ b/integration/run-integration-tests
@@ -12,14 +12,6 @@ sudo apt install -y \
 lxc config set core.trust_password password
 lxc config set core.https_address "[::]"
 
-# force generation of client certificate to an address that doesn't work (http)
-# generate an openssl certificate and key for the remote not verified test
-config_dir="$HOME/.config/lxc"
-mkdir -p "$config_dir"
-openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -sha384 \
-        -keyout "$config_dir/client.key" -out "$config_dir/client.crt" \
-        -nodes -subj "/CN=example.com" -days 3650
-
 if ! lxc storage show default >/dev/null 2>&1; then
     lxc storage create default dir
     lxc profile device add default root disk path=/ pool=default

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -21,7 +21,7 @@ class TestClient(IntegrationTestCase):
     """Tests for `Client`."""
 
     def test_authenticate(self):
-        client = pylxd.Client("https://127.0.0.1:8443/", verify=False)
+        client = pylxd.Client("https://127.0.0.1:8443/")
 
         self.assertFalse(client.trusted)
 
@@ -31,9 +31,7 @@ class TestClient(IntegrationTestCase):
 
     def test_authenticate_with_project(self):
         try:
-            client = pylxd.Client(
-                "https://127.0.0.1:8443/", verify=False, project="test-project"
-            )
+            client = pylxd.Client("https://127.0.0.1:8443/", project="test-project")
         except exceptions.ClientConnectionFailed as e:
             message = str(e)
             if message == "Remote server doesn't handle projects":

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -12,14 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
 import pylxd
 from integration.testing import IntegrationTestCase
 from pylxd import exceptions
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 class TestClient(IntegrationTestCase):

--- a/integration/test_projects.py
+++ b/integration/test_projects.py
@@ -20,9 +20,7 @@ class BaseTestProject(IntegrationTestCase):
     def setUp(self):
         super().setUp()
         try:
-            pylxd.Client(
-                "https://127.0.0.1:8443/", verify=False, project="test-project"
-            )
+            pylxd.Client("https://127.0.0.1:8443/", project="test-project")
         except exceptions.ClientConnectionFailed as e:
             message = str(e)
             if message == "Remote server doesn't handle projects":

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -13,6 +13,7 @@
 #    under the License.
 import json
 import os
+import re
 from enum import Enum
 from typing import NamedTuple
 from urllib import parse
@@ -358,6 +359,16 @@ class Client:
                     and os.path.exists(DEFAULT_CERTS.key)
                 ):
                     cert = DEFAULT_CERTS
+
+                # Try to use an existing server certificate if one exists
+                if isinstance(verify, bool) and endpoint.startswith("https://"):
+                    no_proto = re.sub(r"^https://\[?", "", endpoint)
+                    remote = re.sub(r"]?(:[0-9]+)?$", "", no_proto)
+                    remote_cert_path = os.path.join(
+                        CERTS_PATH, "servercerts", remote + ".crt"
+                    )
+                    if os.path.exists(remote_cert_path):
+                        verify = remote_cert_path
         else:
             if "LXD_DIR" in os.environ:
                 path = os.path.join(os.environ.get("LXD_DIR"), "unix.socket")

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -46,8 +46,8 @@ class Cert(NamedTuple):
 
 
 DEFAULT_CERTS = Cert(
-    cert=os.path.expanduser(os.path.join(CERTS_PATH, CERT_FILE_NAME)),
-    key=os.path.expanduser(os.path.join(CERTS_PATH, KEY_FILE_NAME)),
+    cert=os.path.join(CERTS_PATH, CERT_FILE_NAME),
+    key=os.path.join(CERTS_PATH, KEY_FILE_NAME),
 )  # pragma: no cover
 
 

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -13,7 +13,6 @@
 #    under the License.
 import json
 import os
-import os.path
 from enum import Enum
 from typing import NamedTuple
 from urllib import parse

--- a/pylxd/client.py
+++ b/pylxd/client.py
@@ -28,18 +28,15 @@ from pylxd import exceptions, managers
 
 requests_unixsocket.monkeypatch()
 
-LXD_PATH = ".config/lxc/"
-SNAP_ROOT = os.path.expanduser("~/snap/lxd/current/")
-APT_ROOT = os.path.expanduser("~/")
+SNAP_ROOT = os.path.expanduser("~/snap/lxd/common/config/")
+APT_ROOT = os.path.expanduser("~/.config/lxc/")
 CERT_FILE_NAME = "client.crt"
 KEY_FILE_NAME = "client.key"
-# check that the cert file and key file exist at the appopriate path
-if os.path.exists(
-    os.path.join(SNAP_ROOT, LXD_PATH, CERT_FILE_NAME)
-):  # pragma: no cover
-    CERTS_PATH = os.path.join(SNAP_ROOT, LXD_PATH)  # pragma: no cover
+# check that the cert file and key file exist at the appropriate path
+if os.path.exists(os.path.join(SNAP_ROOT, CERT_FILE_NAME)):  # pragma: no cover
+    CERTS_PATH = SNAP_ROOT  # pragma: no cover
 else:  # pragma: no cover
-    CERTS_PATH = os.path.join(APT_ROOT, LXD_PATH)  # pragma: no cover
+    CERTS_PATH = APT_ROOT  # pragma: no cover
 
 
 class Cert(NamedTuple):

--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -13,7 +13,6 @@
 #    under the License.
 import json
 import os
-import os.path
 from unittest import TestCase, mock
 from urllib import parse
 


### PR DESCRIPTION
Most notable changes:

* use proper path to TLS client certificate/key when using the snap
* opportunistic TLS server verification attempted by looking around for a server cert with a matching name
