### PR TITLE
bugfix: ConnectionResetError on container.execute

### DIFF
--- a/pylxd/models/instance.py
+++ b/pylxd/models/instance.py
@@ -11,7 +11,9 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import errno
 import json
+import logging
 import os
 import stat
 import time
@@ -753,6 +755,17 @@ class _CommandWebsocketClient(WebSocketBaseClient):  # pragma: no cover
     def data(self):
         buffer = b"".join(self.buffer)
         return self._maybe_decode(buffer)
+
+    def unhandled_error(self, error):
+        """
+        Handles the unfriendly socket closures on the server side
+        without showing a confusing error message
+        """
+        if hasattr(error, "errno") and error.errno == errno.ECONNRESET:
+            pass
+        else:
+            logger = logging.getLogger("ws4py")
+            logger.exception("Failed to receive data")
 
 
 class _StdinWebsocket(WebSocketBaseClient):  # pragma: no cover


### PR DESCRIPTION
Closes #523 

LXD considers the socket in non-interactive mode as a pipe, much more than a Web socket. Indeed, once the command is finished executing, LXD "unpolitely" [closes the sockets](https://github.com/lxc/lxd/blob/master/lxd/instance_exec.go#L153) on its side without having the normal conversational close expected for Web Sockets ([see 5.5.1](https://www.rfc-editor.org/rfc/rfc6455#page-36)).

As the `pylxd` client was not informed, it tries to `recv` on a closed socket, hence raising a `ConnectionResetError`. It is arguable who is at fault here, whether the implementation done on `LXD`'s side is invalid, or if the `ws4py` isn't defensive enough with a Web socket being treated as a pipe and not a bi-directional stream by the counterpart.

This merge request suppresses the exception traceback, as in our experience it never happened that the socket was closed by the server in the middle of an execution without the command running successfully, however it appears systematically on successful execution of the command, which is extremely misleading.