### PR TITLE
Pin click at < 8.1.0 to avoid conflict with black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ format =
     black == 20.8b1
     flake8 >= 2.5.0
     isort == 5.6.4
+    click < 8.1.0
 check =
     mypy
 doc =


### PR DESCRIPTION
Black is pinned at `20.8b1` which is incompatible with `click` >= 8.1.0 (see https://stackoverflow.com/q/71673404 )

Bumping Black to something more recent is desirable, but will lead to a big diff. Until that can land, let's just pin click to be before the breaking version.

