### PR TITLE
Pass _APINode.session down to children classes

### DIFF
--- a/pylxd/tests/test_client.py
+++ b/pylxd/tests/test_client.py
@@ -495,6 +495,12 @@ class TestAPINode(TestCase):
         node = client._APINode("http+unix://test.com")
         self.assertIsInstance(node.session, requests_unixsocket.Session)
 
+    def test_session_passed_to_child(self):
+        """session should be shared across path traversl"""
+        parent_node = client._APINode("http+unix://test.com")
+        child_node = parent_node.instances
+        self.assertIs(parent_node.session, child_node.session)
+
     @mock.patch("pylxd.client.requests.Session")
     def test_get(self, Session):
         """Perform a session get."""


### PR DESCRIPTION
Fixes #360

Allow callers to modify the session and have it persisted through the API path traversal.

Signed-off-by: Adam Collard <adam.collard@canonical.com>