### PR TITLE
Pin `urllib3` to 1.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     requests >= 2.20.0
     requests-toolbelt >= 0.8.0
     requests-unixsocket >= 0.1.5
+    urllib3 < 2
     ws4py != 0.3.5, >= 0.3.4  # 0.3.5 is broken for websocket support
 
 [options.extras_require]


### PR DESCRIPTION
Otherwise with `urllib3` `2.0.2`:

```
>>> import pylxd
>>> c = pylxd.Client()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/pylxd/client.py", line 413, in __init__
    response = self.api.get()
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/pylxd/client.py", line 209, in get
    response = self.session.get(self._api_endpoint, *args, **kwargs)
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/requests/sessions.py", line 600, in get
    return self.request("GET", url, **kwargs)
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/urllib3/connectionpool.py", line 790, in urlopen
    response = self._make_request(
  File "/var/lib/juju/agents/unit-lxd-6/charm/venv/urllib3/connectionpool.py", line 496, in _make_request
    conn.request(
TypeError: HTTPConnection.request() got an unexpected keyword argument 'chunked'
```